### PR TITLE
Add HF generation specs (CausalLM & Seq2Seq) and dual-mode HF execution with configurable generation params

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -54,4 +54,12 @@ def preprocess_hf(train, test, meta, **dataset_args):
             label_pad_value=dataset_args.get("label_pad_value", -100),
         )
 
+    if hf_task in {"causal_lm_generation", "seq2seq_generation"}:
+        return preprocess_hf_text_sequence(
+            train, test, meta,
+            hf_model_id=hf_model_id,
+            text_column=dataset_args.get("text_column", "text"),
+            label_column=dataset_args.get("label_column", "label"),
+        )
+
     raise ValueError(f"Unsupported HF text task: {hf_task}")

--- a/mlaas_data_generator/federated/strategies/base.py
+++ b/mlaas_data_generator/federated/strategies/base.py
@@ -43,6 +43,10 @@ def normalize_hf_task(hf_task: str | None) -> str:
         "ner": "token_classification",
         "masked_lm": "fill_mask",
         "mlm": "fill_mask",
+        "text_generation": "causal_lm_generation",
+        "causal_lm": "causal_lm_generation",
+        "text2text": "seq2seq_generation",
+        "text2text_generation": "seq2seq_generation",
     }
     return mapping.get(task, task or "unknown")
 
@@ -63,6 +67,8 @@ def canonical_task_family(task_type: str | None, hf_task: str | None = None) -> 
             return "fill_mask"
         if hf == "sequence_classification" or hf == "unknown":
             return "classification"
+        if hf in {"causal_lm_generation", "seq2seq_generation"}:
+            return "generation"
         return f"hf_{hf}"
     return "unknown"
 
@@ -73,6 +79,7 @@ def canonical_label_format(task_family: str) -> str:
         "token_classification": "token_labels",
         "fill_mask": "token_labels",
         "regression": "continuous",
+        "generation": "token_labels",
         "clustering": "cluster_id",
     }
     return mapping.get(task_family, "unknown")
@@ -87,6 +94,8 @@ def canonical_metric_names(task_family: str, metric_key: str) -> tuple[str, str 
         return ("masked_accuracy", "perplexity_proxy")
     if task_family == "regression":
         return ("rmse", "mae")
+    if task_family == "generation":
+        return ("exact_match", "token_accuracy")
     if task_family == "clustering":
         return ("silhouette", None)
     return ((metric_key or "metric").lower(), None)
@@ -137,7 +146,8 @@ class TaskStrategy:
                     extra[key] = self.config[key]
         else:
             for key in ("rf_trees", "rf_max_depth", "mobilenet_trainable", "n_estimators", "max_depth",
-                        "hf_model_id", "max_length", "device", "hf_task"):
+                        "hf_model_id", "max_length", "device", "hf_task",
+                        "max_new_tokens", "num_beams", "do_sample", "temperature", "top_k", "top_p", "length_penalty"):
                 if key in self.config:
                     extra[key] = self.config[key]
             
@@ -146,7 +156,8 @@ class TaskStrategy:
 
         ds_args = self.config.get("dataset_args", {}) or {}
  
-        for key in ("hf_model_id", "max_length", "device", "hf_task"):
+        for key in ("hf_model_id", "max_length", "device", "hf_task",
+                    "max_new_tokens", "num_beams", "do_sample", "temperature", "top_k", "top_p", "length_penalty"):
             if key in ds_args and key not in extra:
                 extra[key] = ds_args[key]
 

--- a/mlaas_data_generator/federated/strategies/hf_strategy.py
+++ b/mlaas_data_generator/federated/strategies/hf_strategy.py
@@ -59,6 +59,13 @@ class HFStrategy(TaskStrategy):
             "batch_size": self.knobs.get("batch_size"),
             "local_epochs": self.knobs.get("local_epochs"),
             "lr": self.knobs.get("learning_rate"),
+            "max_new_tokens": ds_args.get("max_new_tokens") or self.config.get("max_new_tokens"),
+            "num_beams": ds_args.get("num_beams") or self.config.get("num_beams"),
+            "do_sample": ds_args.get("do_sample") if ds_args.get("do_sample") is not None else self.config.get("do_sample"),
+            "temperature": ds_args.get("temperature") or self.config.get("temperature"),
+            "top_k": ds_args.get("top_k") or self.config.get("top_k"),
+            "top_p": ds_args.get("top_p") or self.config.get("top_p"),
+            "length_penalty": ds_args.get("length_penalty") or self.config.get("length_penalty"),
         }
 
         dataset = {
@@ -129,7 +136,7 @@ class HFStrategy(TaskStrategy):
         try:
             if self.inference_only:
                 adapter = global_model if global_model is not None else self.build_model()
-                loss, primary, secondary, qos = adapter.evaluate(x, y)
+                loss, primary, secondary, qos = adapter.evaluate(x, y, inference_only=True)
 
                 duration = time.time() - start
                 usage = tracker.stop(duration)

--- a/mlaas_data_generator/models/adapters/hf_adapter.py
+++ b/mlaas_data_generator/models/adapters/hf_adapter.py
@@ -1,7 +1,13 @@
 from .hf_core import HFCore
-from .hf_task import SequenceClassificationSpec, SentenceSimilaritySpec, TokenClassificationSpec, FillMaskSpec
+from .hf_task import (
+    SequenceClassificationSpec,
+    SentenceSimilaritySpec,
+    TokenClassificationSpec,
+    FillMaskSpec,
+    CausalLMGenerationSpec,
+    Seq2SeqGenerationSpec,
+)
 import time
-
 
 
 class TransformersTextFineTuneAdapter:
@@ -12,6 +18,7 @@ class TransformersTextFineTuneAdapter:
       - x is dict-of-arrays: {"input_ids": ..., "attention_mask": ...}
       - x can still be legacy raw texts or token lists (kept for backwards compatibility)
     """
+
     def __init__(
         self,
         model_id,
@@ -23,18 +30,20 @@ class TransformersTextFineTuneAdapter:
         label_pad_value=-100,
         multilabel=False,
         label_format="single_index",
+        generation_config=None,
     ):
         if hf_task == "token_classification":
             spec = TokenClassificationSpec(multilabel=multilabel, label_format=label_format)
-        
         elif hf_task == "sentence_similarity":
             spec = SentenceSimilaritySpec(is_regression=(str(label_format).lower() == "continuous"))
-
         elif hf_task == "fill_mask":
             spec = FillMaskSpec()
-            
+        elif hf_task in {"causal_lm_generation", "causal_lm", "text_generation"}:
+            spec = CausalLMGenerationSpec()
+        elif hf_task in {"seq2seq_generation", "text2text_generation", "text2text"}:
+            spec = Seq2SeqGenerationSpec()
         else:
-             spec = SequenceClassificationSpec(multilabel=multilabel, label_format=label_format)
+            spec = SequenceClassificationSpec(multilabel=multilabel, label_format=label_format)
 
         self.core = HFCore(
             model_id=model_id,
@@ -44,6 +53,7 @@ class TransformersTextFineTuneAdapter:
             device=device,
             task_spec=spec,
             label_pad_value=int(label_pad_value),
+            generation_config=generation_config,
         )
 
         self.model_id = model_id
@@ -61,16 +71,11 @@ class TransformersTextFineTuneAdapter:
         self.core.set_weights(weights_dict)
 
     def fit(self, x, y, epochs=1, lr=5e-5):
-        # x may be dict-of-arrays (new loader schema) or legacy list-like
         return self.core.finetune(x, y, epochs=epochs, lr=lr)
 
-    def evaluate(self, x, y):
-        # core returns (loss, primary, secondary, qos)
-        loss, primary, secondary, qos = self.core.eval(x, y)
-
-        acc = primary
-        f1 = secondary
-        return loss, acc, f1, qos
+    def evaluate(self, x, y, inference_only=False):
+        loss, primary, secondary, qos = self.core.eval(x, y, inference_only=inference_only)
+        return loss, primary, secondary, qos
 
 
 class TransformersTextClassifierAdapter:
@@ -78,25 +83,54 @@ class TransformersTextClassifierAdapter:
     Inference-style adapter (loads an already-finetuned sequence classification model_id).
     Uses HFCore batching/eval utilities, including dict-of-arrays support.
     """
+
     def __init__(
         self,
         model_id,
         max_length=128,
         batch_size=16,
         device=None,
+        hf_task="sequence_classification",
+        generation_config=None,
     ):
+        task = str(hf_task or "sequence_classification").lower().replace("-", "_")
+        if task in {"causal_lm_generation", "causal_lm", "text_generation"}:
+            spec = CausalLMGenerationSpec()
+        elif task in {"seq2seq_generation", "text2text_generation", "text2text"}:
+            spec = Seq2SeqGenerationSpec()
+        elif task == "fill_mask":
+            spec = FillMaskSpec()
+        elif task == "token_classification":
+            spec = TokenClassificationSpec()
+        elif task == "sentence_similarity":
+            spec = SentenceSimilaritySpec()
+        else:
+            spec = SequenceClassificationSpec()
+
         core = HFCore(
             model_id=model_id,
             num_labels=None,
             max_length=max_length,
             batch_size=batch_size,
             device=device,
-            task_spec=SequenceClassificationSpec(),
+            task_spec=spec,
+            generation_config=generation_config,
         )
 
         transformers = core.transformers
         model_load_start = time.time()
-        core.model = transformers.AutoModelForSequenceClassification.from_pretrained(model_id)
+        if core.model is None:
+            if task in {"causal_lm_generation", "causal_lm", "text_generation"}:
+                core.model = transformers.AutoModelForCausalLM.from_pretrained(model_id)
+            elif task in {"seq2seq_generation", "text2text_generation", "text2text"}:
+                core.model = transformers.AutoModelForSeq2SeqLM.from_pretrained(model_id)
+            elif task == "fill_mask":
+                core.model = transformers.AutoModelForMaskedLM.from_pretrained(model_id)
+            elif task == "token_classification":
+                core.model = transformers.AutoModelForTokenClassification.from_pretrained(model_id)
+            else:
+                core.model = transformers.AutoModelForSequenceClassification.from_pretrained(model_id)
+
         core.model.to(core.device)
         core.model.eval()
         core.cold_start_time += float(time.time() - model_load_start)
@@ -107,10 +141,8 @@ class TransformersTextClassifierAdapter:
         self.batch_size = int(batch_size)
         self.device = self.core.device
 
-    def evaluate(self, x, y):
-        loss, primary, secondary, qos = self.core.eval(x, y)
-        acc = primary
-        f1 = secondary
+    def evaluate(self, x, y, inference_only=True):
+        loss, primary, secondary, qos = self.core.eval(x, y, inference_only=inference_only)
 
         qos = dict(qos)
         if "eval_latency_ms_mean" in qos:
@@ -124,4 +156,4 @@ class TransformersTextClassifierAdapter:
         if "eval_throughput_eps" in qos:
             qos["throughput_eps"] = qos.pop("eval_throughput_eps")
 
-        return loss, acc, f1, qos
+        return loss, primary, secondary, qos

--- a/mlaas_data_generator/models/adapters/hf_core.py
+++ b/mlaas_data_generator/models/adapters/hf_core.py
@@ -12,6 +12,7 @@ class HFCore:
       - xs can be dict-of-arrays (preferred, from loader preprocessors)
       - xs can be list of raw texts or list-of-token-lists (legacy)
     """
+
     def __init__(
         self,
         model_id,
@@ -21,6 +22,7 @@ class HFCore:
         device=None,
         task_spec=None,
         label_pad_value=-100,
+        generation_config=None,
     ):
         try:
             import torch
@@ -42,11 +44,15 @@ class HFCore:
         self.device = self._resolve_device(device)
 
         self.task_spec = task_spec or SequenceClassificationSpec()
+        self.generation_config = self._resolve_generation_config(generation_config)
         cold_start_begin = time.time()
         try:
             self.tokenizer = transformers.AutoTokenizer.from_pretrained(model_id, use_fast=True)
         except Exception:
             self.tokenizer = transformers.AutoTokenizer.from_pretrained(model_id, use_fast=False)
+
+        if getattr(self.tokenizer, "pad_token_id", None) is None and getattr(self.tokenizer, "eos_token_id", None) is not None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
 
         self.model = None
         self.weight_format = None
@@ -57,6 +63,33 @@ class HFCore:
             self.model.to(self.device)
         self.cold_start_time = float(time.time() - cold_start_begin)
 
+    def _resolve_generation_config(self, generation_config):
+        defaults = {
+            "max_new_tokens": 64,
+            "num_beams": 1,
+            "do_sample": False,
+            "temperature": 1.0,
+            "top_k": 50,
+            "top_p": 1.0,
+            "length_penalty": 1.0,
+        }
+        cfg = dict(defaults)
+        if isinstance(generation_config, dict):
+            cfg.update({k: generation_config[k] for k in defaults.keys() if k in generation_config and generation_config[k] is not None})
+        cfg["max_new_tokens"] = int(cfg["max_new_tokens"])
+        cfg["num_beams"] = int(cfg["num_beams"])
+        cfg["do_sample"] = bool(cfg["do_sample"])
+        cfg["temperature"] = float(cfg["temperature"])
+        cfg["top_k"] = int(cfg["top_k"])
+        cfg["top_p"] = float(cfg["top_p"])
+        cfg["length_penalty"] = float(cfg["length_penalty"])
+
+        if not cfg["do_sample"]:
+            cfg["temperature"] = 1.0
+        if cfg["num_beams"] > 1:
+            cfg["do_sample"] = False
+
+        return cfg
 
     def _resolve_device(self, device):
         torch = self.torch
@@ -73,11 +106,10 @@ class HFCore:
             return torch_directml.device()
         except Exception:
             return "cpu"
-        
+
     def _batch_iter(self, xs, ys):
         bs = self.batch_size
 
-        # New loader path: dict of arrays
         if isinstance(xs, dict):
             n = len(next(iter(xs.values())))
             for i in range(0, n, bs):
@@ -86,7 +118,6 @@ class HFCore:
                 yield xb, yb
             return
 
-        # Legacy path: list-like
         n = len(xs)
         for i in range(0, n, bs):
             xb = xs[i:i + bs]
@@ -124,8 +155,7 @@ class HFCore:
             if labels_t is None or labels_t.ndim < 2:
                 return 0
             return int((labels_t != int(ignore_index)).sum().detach().cpu().item())
-        
-        # xs may be dict-of-arrays or list-like; do not force list(xs)
+
         y_local = ys
 
         self.model.train()
@@ -149,18 +179,21 @@ class HFCore:
                     torch,
                     self.device,
                     ignore_index=self.label_pad_value,
+                    inference_only=False,
                 )
 
                 optimizer.zero_grad(set_to_none=True)
-                outputs = self.model(**enc)
+                model_inputs = self.task_spec.build_forward_inputs(enc, labels_t=labels_t, inference_only=False)
+                outputs = self.model(**model_inputs)
                 logits = outputs.logits
-                loss = self.task_spec.loss_fn(torch, logits, labels_t, extra)
+                loss = self.task_spec.extract_loss(torch, outputs, logits, labels_t, extra)
+                if loss is None:
+                    raise ValueError("Supervised fine-tune mode requires labels/loss-capable batch")
                 loss.backward()
                 optimizer.step()
 
                 total_tokens += _count_supervised_tokens(labels_t, self.label_pad_value)
 
-                # batch size for dict path or list path
                 if isinstance(labels_t, torch.Tensor) and labels_t.ndim >= 2:
                     w = _count_supervised_tokens(labels_t, self.label_pad_value)
                 elif isinstance(xb, dict):
@@ -207,7 +240,7 @@ class HFCore:
             "hf_weights_format": self.weight_format,
         }
 
-    def eval(self, xs, ys):
+    def eval(self, xs, ys, inference_only=False):
         torch = self.torch
 
         def _count_supervised_tokens(labels_t, ignore_index):
@@ -226,7 +259,6 @@ class HFCore:
         preds_all = []
         labels_all = []
 
-        # evaluation sample count
         if isinstance(xs, dict):
             n_eval = len(next(iter(xs.values())))
         else:
@@ -246,43 +278,49 @@ class HFCore:
                     torch,
                     self.device,
                     ignore_index=self.label_pad_value,
+                    inference_only=bool(inference_only),
                 )
 
-                outputs = self.model(**enc)
-                logits = outputs.logits
-                pred_t = self.task_spec.preds_from_logits(torch, logits, extra)
+                if bool(inference_only) and bool(getattr(self.task_spec, "supports_generation", False)):
+                    pred_t = self.task_spec.generate_predictions(
+                        self.model,
+                        enc,
+                        self.tokenizer,
+                        torch,
+                        self.generation_config,
+                    )
+                    preds_all.append(pred_t.detach().cpu().numpy())
+                else:
+                    model_inputs = self.task_spec.build_forward_inputs(enc, labels_t=labels_t, inference_only=bool(inference_only))
+                    outputs = self.model(**model_inputs)
+                    logits = outputs.logits
+                    pred_t = self.task_spec.preds_from_logits(torch, logits, extra)
+                    preds_all.append(pred_t.detach().cpu().numpy())
 
-                preds_all.append(pred_t.detach().cpu().numpy())
+                    loss = self.task_spec.extract_loss(torch, outputs, logits, labels_t, extra)
+                    if loss is not None and labels_t is not None:
+                        labels_all.append(labels_t.detach().cpu().numpy())
+                        total_tokens += _count_supervised_tokens(labels_t, self.label_pad_value)
 
-                if labels_t is not None:
+                        if labels_t.ndim >= 2:
+                            w = _count_supervised_tokens(labels_t, self.label_pad_value)
+                        elif isinstance(xb, dict):
+                            w = len(next(iter(xb.values())))
+                        else:
+                            w = len(xb)
+
+                        total_loss += float(loss.detach().cpu().item()) * float(max(1, w))
+                        total_loss_weight += int(max(1, w))
+
+                if labels_t is not None and bool(inference_only) and yb is not None:
                     labels_all.append(labels_t.detach().cpu().numpy())
-
-                    loss = self.task_spec.loss_fn(torch, logits, labels_t, extra)
-                    total_tokens += _count_supervised_tokens(labels_t, self.label_pad_value)
-
-                    if labels_t.ndim >= 2:
-                        w = _count_supervised_tokens(labels_t, self.label_pad_value)
-                    elif isinstance(xb, dict):
-                        w = len(next(iter(xb.values())))
-                    else:
-                        w = len(xb)
-
-                    total_loss += float(loss.detach().cpu().item()) * float(max(1, w))
-                    total_loss_weight += int(max(1, w))
 
                 latencies_ms.append((time.time() - t0) * 1000.0)
 
         duration_s = time.time() - t_start
 
-        if labels_all:
-            y_true_np = np.concatenate(labels_all, axis=0)
-        else:
-            y_true_np = np.asarray([], dtype="int64")
-
-        if preds_all:
-            y_pred_np = np.concatenate(preds_all, axis=0)
-        else:
-            y_pred_np = np.asarray([], dtype="int64")
+        y_true_np = np.concatenate(labels_all, axis=0) if labels_all else np.asarray([], dtype="int64")
+        y_pred_np = np.concatenate(preds_all, axis=0) if preds_all else np.asarray([], dtype="int64")
 
         if y_true_np.size == 0 or y_pred_np.size == 0:
             primary = np.nan
@@ -290,12 +328,11 @@ class HFCore:
             loss_mean = np.nan
         else:
             m = self.task_spec.metrics(y_true_np, y_pred_np, y_extra=extra)
-
             primary = float(m.get("primary", np.nan))
             secondary = float(m.get("secondary", np.nan))
-            loss_mean = float(total_loss / max(1, total_loss_weight))
+            loss_mean = float(total_loss / max(1, total_loss_weight)) if total_loss_weight > 0 else np.nan
 
-            if getattr(self.task_spec, "name", None) == "fill_mask":
+            if getattr(self.task_spec, "name", None) == "fill_mask" and loss_mean == loss_mean:
                 try:
                     secondary = float(np.exp(np.clip(loss_mean, a_min=-50.0, a_max=50.0)))
                 except Exception:
@@ -326,6 +363,9 @@ class HFCore:
             "hf_task": getattr(self.task_spec, "name", None),
             "label_pad_value": int(self.label_pad_value),
             "hf_weights_format": self.weight_format,
+            "inference_only": bool(inference_only),
         }
+        if getattr(self.task_spec, "supports_generation", False):
+            qos.update({f"generation_{k}": v for k, v in self.generation_config.items()})
 
         return loss_mean, primary, secondary, qos

--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -16,11 +16,12 @@ class HFTaskSpec:
     name = "base"
 
     requires_num_labels = True
+    supports_generation = False
 
     def build_model(self, transformers, model_id, num_labels):
         raise NotImplementedError
 
-    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100):
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
         """
         Returns (enc_dict, labels_tensor_or_none, extra_dict)
         extra_dict can hold masks etc.
@@ -39,6 +40,22 @@ class HFTaskSpec:
           - primary (float)
           - secondary (float or np.nan)
         """
+        raise NotImplementedError
+
+    def build_forward_inputs(self, enc, labels_t=None, inference_only=False):
+        model_inputs = dict(enc)
+        if labels_t is not None and not inference_only:
+            model_inputs["labels"] = labels_t
+        return model_inputs
+
+    def extract_loss(self, torch, outputs, logits, labels_t, extra):
+        if labels_t is not None and hasattr(outputs, "loss") and outputs.loss is not None:
+            return outputs.loss
+        if labels_t is None:
+            return None
+        return self.loss_fn(torch, logits, labels_t, extra)
+
+    def generate_predictions(self, model, enc, tokenizer, torch, generation_config):
         raise NotImplementedError
 
 
@@ -106,7 +123,7 @@ class SequenceClassificationSpec(HFTaskSpec):
                 raise
         return model
 
-    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100):
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
         label_mode = self._infer_label_mode(yb)
         batch_multilabel = self._is_multilabel_mode(label_mode, {"label_mode": label_mode})
         # New loader path: already tokenised dict of arrays
@@ -246,7 +263,7 @@ class TokenClassificationSpec(HFTaskSpec):
             prev = wid
         return aligned
 
-    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100):
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
         label_mode = self._infer_label_mode(yb)
 
         if isinstance(xb, dict):
@@ -376,7 +393,7 @@ class SentenceSimilaritySpec(HFTaskSpec):
                 raise
         return model
 
-    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100):
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
         if isinstance(xb, dict):
             enc = {k: torch.tensor(v, dtype=torch.long, device=device) for k, v in xb.items()}
         elif isinstance(xb, (list, tuple)) and xb and isinstance(xb[0], (list, tuple)) and len(xb[0]) == 2:
@@ -461,7 +478,7 @@ class FillMaskSpec(HFTaskSpec):
                 raise
         return model
 
-    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100):
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
         if isinstance(xb, dict):
             enc = {k: torch.tensor(v, dtype=torch.long, device=device) for k, v in xb.items()}
         else:
@@ -511,3 +528,137 @@ class FillMaskSpec(HFTaskSpec):
         acc = float((yp == yt).mean())
 
         return {"primary": acc, "secondary": np.nan}
+
+
+class CausalLMGenerationSpec(HFTaskSpec):
+    name = "causal_lm_generation"
+    requires_num_labels = False
+    supports_generation = True
+
+    def build_model(self, transformers, model_id, num_labels):
+        AutoModel = transformers.AutoModelForCausalLM
+        self.weight_format = None
+        try:
+            model = AutoModel.from_pretrained(model_id, use_safetensors=True)
+            self.weight_format = "safetensors"
+        except OSError as e:
+            if "safetensors" in str(e).lower():
+                model = AutoModel.from_pretrained(model_id, use_safetensors=False)
+                self.weight_format = "pickle"
+            else:
+                raise
+        return model
+
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
+        if isinstance(xb, dict):
+            enc = {k: torch.tensor(v, dtype=torch.long, device=device) for k, v in xb.items() if k in {"input_ids", "attention_mask", "token_type_ids"}}
+            labels_t = None if yb is None else torch.tensor(yb, dtype=torch.long, device=device)
+            return enc, labels_t, {"ignore_index": int(ignore_index)}
+
+        prompts = list(xb)
+        if yb is None or inference_only:
+            enc = tokenizer(prompts, truncation=True, padding=True, max_length=int(max_length), return_tensors="pt")
+            return {k: v.to(device) for k, v in enc.items()}, None, {"ignore_index": int(ignore_index)}
+
+        prompt_tokens = tokenizer(prompts, truncation=True, padding=False, max_length=int(max_length), add_special_tokens=True)
+        target_tokens = tokenizer(list(yb), truncation=True, padding=False, max_length=int(max_length), add_special_tokens=False)
+
+        pad_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+        eos_id = tokenizer.eos_token_id if tokenizer.eos_token_id is not None else pad_id
+
+        batch_ids, batch_masks, batch_labels = [], [], []
+        for p_ids, t_ids in zip(prompt_tokens["input_ids"], target_tokens["input_ids"]):
+            full_ids = (p_ids + t_ids + [eos_id])[: int(max_length)]
+            full_labels = ([-100] * len(p_ids) + t_ids + [eos_id])[: int(max_length)]
+            pad_len = int(max_length) - len(full_ids)
+            batch_ids.append(full_ids + [pad_id] * pad_len)
+            batch_masks.append([1] * len(full_ids) + [0] * pad_len)
+            batch_labels.append(full_labels + [-100] * pad_len)
+
+        enc = {
+            "input_ids": torch.tensor(batch_ids, dtype=torch.long, device=device),
+            "attention_mask": torch.tensor(batch_masks, dtype=torch.long, device=device),
+        }
+        labels_t = torch.tensor(batch_labels, dtype=torch.long, device=device)
+        return enc, labels_t, {"ignore_index": int(ignore_index)}
+
+    def loss_fn(self, torch, logits, labels_t, extra):
+        ignore_index = int(extra.get("ignore_index", -100))
+        return torch.nn.functional.cross_entropy(logits.transpose(1, 2), labels_t, ignore_index=ignore_index)
+
+    def preds_from_logits(self, torch, logits, extra):
+        return torch.argmax(logits, dim=-1)
+
+    def generate_predictions(self, model, enc, tokenizer, torch, generation_config):
+        generated = model.generate(**enc, **generation_config)
+        in_len = enc["input_ids"].shape[1]
+        return generated[:, in_len:]
+
+    def metrics(self, y_true, y_pred, y_extra=None):
+        y_true = np.asarray(y_true)
+        y_pred = np.asarray(y_pred)
+        if y_true.size == 0 or y_pred.size == 0:
+            return {"primary": np.nan, "secondary": np.nan}
+        common = min(y_true.shape[-1], y_pred.shape[-1])
+        yt = y_true[..., :common]
+        yp = y_pred[..., :common]
+        exact = float(np.all(yt == yp, axis=-1).mean())
+        tok_acc = float((yt == yp).mean())
+        return {"primary": exact, "secondary": tok_acc}
+
+
+class Seq2SeqGenerationSpec(HFTaskSpec):
+    name = "seq2seq_generation"
+    requires_num_labels = False
+    supports_generation = True
+
+    def build_model(self, transformers, model_id, num_labels):
+        AutoModel = transformers.AutoModelForSeq2SeqLM
+        self.weight_format = None
+        try:
+            model = AutoModel.from_pretrained(model_id, use_safetensors=True)
+            self.weight_format = "safetensors"
+        except OSError as e:
+            if "safetensors" in str(e).lower():
+                model = AutoModel.from_pretrained(model_id, use_safetensors=False)
+                self.weight_format = "pickle"
+            else:
+                raise
+        return model
+
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
+        if isinstance(xb, dict):
+            enc = {k: torch.tensor(v, dtype=torch.long, device=device) for k, v in xb.items() if k in {"input_ids", "attention_mask", "token_type_ids"}}
+            labels_t = None if yb is None else torch.tensor(yb, dtype=torch.long, device=device)
+            return enc, labels_t, {"ignore_index": int(ignore_index)}
+
+        enc = tokenizer(xb, truncation=True, padding=True, max_length=int(max_length), return_tensors="pt")
+        enc = {k: v.to(device) for k, v in enc.items()}
+        labels_t = None
+        if yb is not None and not inference_only:
+            targets = tokenizer(text_target=list(yb), truncation=True, padding=True, max_length=int(max_length), return_tensors="pt")
+            labels_t = targets["input_ids"].to(device)
+            labels_t = labels_t.masked_fill(labels_t == tokenizer.pad_token_id, int(ignore_index))
+        return enc, labels_t, {"ignore_index": int(ignore_index)}
+
+    def loss_fn(self, torch, logits, labels_t, extra):
+        ignore_index = int(extra.get("ignore_index", -100))
+        return torch.nn.functional.cross_entropy(logits.transpose(1, 2), labels_t, ignore_index=ignore_index)
+
+    def preds_from_logits(self, torch, logits, extra):
+        return torch.argmax(logits, dim=-1)
+
+    def generate_predictions(self, model, enc, tokenizer, torch, generation_config):
+        return model.generate(**enc, **generation_config)
+
+    def metrics(self, y_true, y_pred, y_extra=None):
+        y_true = np.asarray(y_true)
+        y_pred = np.asarray(y_pred)
+        if y_true.size == 0 or y_pred.size == 0:
+            return {"primary": np.nan, "secondary": np.nan}
+        common = min(y_true.shape[-1], y_pred.shape[-1])
+        yt = y_true[..., :common]
+        yp = y_pred[..., :common]
+        exact = float(np.all(yt == yp, axis=-1).mean())
+        tok_acc = float((yt == yp).mean())
+        return {"primary": exact, "secondary": tok_acc}

--- a/mlaas_data_generator/models/builders.py
+++ b/mlaas_data_generator/models/builders.py
@@ -31,6 +31,10 @@ def _normalize_hf_task_name(hf_task):
         "token_cls": "token_classification",
         "masked_lm": "fill_mask",
         "mlm": "fill_mask",
+        "text_generation": "causal_lm_generation",
+        "causal_lm": "causal_lm_generation",
+        "text2text": "seq2seq_generation",
+        "text2text_generation": "seq2seq_generation",
     }
     return aliases.get(task, task)
 
@@ -97,8 +101,18 @@ def create_model(
         multilabel = label_format in {"multilabel", "multihot"}
         multilabel = bool(kwargs.get("multilabel", multilabel))
         resolved_num_labels = infer_num_labels(meta if isinstance(meta, dict) else None, fallback=num_classes)
-        if hf_task == "fill_mask":
+        if hf_task in {"fill_mask", "causal_lm_generation", "seq2seq_generation"}:
             resolved_num_labels = None
+
+        generation_config = {
+            "max_new_tokens": kwargs.get("max_new_tokens", (meta or {}).get("max_new_tokens") if isinstance(meta, dict) else None),
+            "num_beams": kwargs.get("num_beams", (meta or {}).get("num_beams") if isinstance(meta, dict) else None),
+            "do_sample": kwargs.get("do_sample", (meta or {}).get("do_sample") if isinstance(meta, dict) else None),
+            "temperature": kwargs.get("temperature", (meta or {}).get("temperature") if isinstance(meta, dict) else None),
+            "top_k": kwargs.get("top_k", (meta or {}).get("top_k") if isinstance(meta, dict) else None),
+            "top_p": kwargs.get("top_p", (meta or {}).get("top_p") if isinstance(meta, dict) else None),
+            "length_penalty": kwargs.get("length_penalty", (meta or {}).get("length_penalty") if isinstance(meta, dict) else None),
+        }
 
         return TransformersTextFineTuneAdapter(
             model_id=model_id,
@@ -110,6 +124,7 @@ def create_model(
             label_pad_value=label_pad_value,
             multilabel=multilabel,
             label_format=label_format,
+            generation_config=generation_config,
         )
 
     if model_choice in ("hf", "hf_text", "transformers"):
@@ -121,6 +136,11 @@ def create_model(
         model_id = model_id or kwargs.get("hf_model_id") or kwargs.get("model_id") or kwargs.get("model_name")
         if not model_id:
             raise ValueError("HF model_type requires hf_model_id=<huggingface_model_repo_id>")
+
+        hf_task = None
+        if isinstance(meta, dict):
+            hf_task = meta.get("hf_task")
+        hf_task = _normalize_hf_task_name(hf_task or kwargs.get("hf_task", "sequence_classification"))
 
         max_length = kwargs.get("max_length", None)
         if max_length is None and isinstance(meta, dict):
@@ -137,12 +157,23 @@ def create_model(
         batch_size = int(kwargs.get("batch_size", 16))
         device = kwargs.get("device", None)
 
-        # If you only support sequence-classification inference, you can omit hf_task here.
+        generation_config = {
+            "max_new_tokens": kwargs.get("max_new_tokens", (meta or {}).get("max_new_tokens") if isinstance(meta, dict) else None),
+            "num_beams": kwargs.get("num_beams", (meta or {}).get("num_beams") if isinstance(meta, dict) else None),
+            "do_sample": kwargs.get("do_sample", (meta or {}).get("do_sample") if isinstance(meta, dict) else None),
+            "temperature": kwargs.get("temperature", (meta or {}).get("temperature") if isinstance(meta, dict) else None),
+            "top_k": kwargs.get("top_k", (meta or {}).get("top_k") if isinstance(meta, dict) else None),
+            "top_p": kwargs.get("top_p", (meta or {}).get("top_p") if isinstance(meta, dict) else None),
+            "length_penalty": kwargs.get("length_penalty", (meta or {}).get("length_penalty") if isinstance(meta, dict) else None),
+        }
+
         return TransformersTextClassifierAdapter(
             model_id=model_id,
             max_length=max_length,
             batch_size=batch_size,
             device=device,
+            hf_task=hf_task,
+            generation_config=generation_config,
         )
 
     # ----------------------------


### PR DESCRIPTION
### Motivation
- Extend the HF task-spec layer to support text generation workloads (prompt→continuation and text2text) alongside existing classification/token tasks. 
- Provide a single, consistent runtime that can run both supervised fine-tuning (loss + train metrics) and inference-only generation (no loss path) for HF models.
- Allow generation behavior to be controlled from manifests/configs with safe, sensible defaults so orchestration and strategy code can pass generation knobs.

### Description
- Added two new task specs: `CausalLMGenerationSpec` and `Seq2SeqGenerationSpec` implementing model construction, batch encoding (teacher-forcing labels where applicable), loss contract, `generate()`-based decoding, and simple generation metrics (exact match / token-accuracy). 
- Extended `HFTaskSpec` base with reusable hooks `build_forward_inputs`, `extract_loss`, `generate_predictions`, and a `supports_generation` flag so specs can express forward-pass / generation behavior uniformly. 
- Implemented dual-mode execution in `HFCore` so supervised fine-tune uses label/loss paths and inference-only mode uses spec-level generation when available, and added generation QoS reporting. 
- Plumbed external generation configuration (`max_new_tokens`, `num_beams`, `do_sample`, `temperature`, `top_k`, `top_p`, `length_penalty`) through `create_model` → adapters → `HFCore` with safe defaults, updated adapter routing to register new specs, and routed generation aliases through normalizers and preprocessors. 

### Testing
- Ran Python compile checks: `python -m py_compile` on all modified modules (passed). 
- Attempted unit test: `pytest -q mlaas_data_generator/test/test_hf_loader.py` failed during collection due to missing runtime dependency (`numpy` not installed) in the test environment, not due to code syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7af32300c8330a2050ccc778e47de)