### PR TITLE
Add generation-aware HF preprocessors and task specs for causal LM and seq2seq

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -2,6 +2,45 @@ from .hf_text_sequence import preprocess_hf_text_sequence
 from .hf_text_similarity import preprocess_hf_text_similarity
 from .hf_text_fill_mask import preprocess_hf_text_fill_mask
 from .hf_text_token import preprocess_hf_text_token
+from .hf_text_generation import preprocess_hf_text_causal_lm, preprocess_hf_text_seq2seq
+
+
+TASK_EXPECTED_BATCH_KEYS = {
+    "sequence_classification": {"input_ids", "attention_mask"},
+    "token_classification": {"input_ids", "attention_mask"},
+    "sentence_similarity": {"input_ids", "attention_mask"},
+    "fill_mask": {"input_ids", "attention_mask"},
+    "causal_lm": {"input_ids", "attention_mask"},
+    "seq2seq": {"input_ids", "attention_mask"},
+}
+
+
+def _resolve_column_arg(dataset_args, config_key, default=None):
+    mapping = dataset_args.get("column_mapping") or {}
+    if config_key in mapping:
+        return mapping[config_key]
+    return dataset_args.get(config_key, default)
+
+
+def _validate_hf_preprocessor_output(train, test, hf_task):
+    x_train, y_train = train
+    x_test, y_test = test
+
+    if not isinstance(x_train, dict) or not isinstance(x_test, dict):
+        raise ValueError(f"HF task '{hf_task}' requires dict feature outputs from preprocessor")
+
+    expected = TASK_EXPECTED_BATCH_KEYS.get(hf_task, set())
+    missing_train = expected.difference(x_train.keys())
+    missing_test = expected.difference(x_test.keys())
+
+    if missing_train or missing_test:
+        raise ValueError(
+            f"Preprocessor output keys do not match HF task '{hf_task}'. "
+            f"Missing train={sorted(missing_train)} test={sorted(missing_test)}"
+        )
+
+    if y_train is None or y_test is None:
+        raise ValueError(f"HF task '{hf_task}' requires non-null labels")
 
 def preprocess_hf(train, test, meta, **dataset_args):
     modality = meta.get("modality", "text")
@@ -17,41 +56,83 @@ def preprocess_hf(train, test, meta, **dataset_args):
         raise ValueError("HF preprocessing requires hf_model_id in dataset_args")
 
     if hf_task == "sequence_classification":
-        return preprocess_hf_text_sequence(
+        out = preprocess_hf_text_sequence(
             train, test, meta,
             hf_model_id=hf_model_id,
-            text_column=dataset_args.get("text_column", "text"),
-            label_column=dataset_args.get("label_column", "label"),
+            text_column=_resolve_column_arg(dataset_args, "text_column", "text"),
+            label_column=_resolve_column_arg(dataset_args, "label_column", "label"),
         )
+        _validate_hf_preprocessor_output(out[0], out[1], "sequence_classification")
+        return out
 
     if hf_task == "token_classification":
-        return preprocess_hf_text_token(
+        out = preprocess_hf_text_token(
             train, test, meta,
             hf_model_id=hf_model_id,
-            tokens_column=dataset_args.get("tokens_column") or dataset_args.get("text_column"),
-            label_column=dataset_args.get("label_column"),
+            tokens_column=_resolve_column_arg(dataset_args, "tokens_column") or _resolve_column_arg(dataset_args, "text_column"),
+            label_column=_resolve_column_arg(dataset_args, "label_column"),
         )
+        _validate_hf_preprocessor_output(out[0], out[1], "token_classification")
+        return out
     
     if hf_task == "sentence_similarity":
-        return preprocess_hf_text_similarity(
+        out = preprocess_hf_text_similarity(
             train,
             test,
             meta,
             hf_model_id=hf_model_id,
-            text_column=dataset_args.get("text_column", ["sentence1", "sentence2"]),
-            label_column=dataset_args.get("label_column", "label"),
+            text_column=_resolve_column_arg(dataset_args, "text_column", ["sentence1", "sentence2"]),
+            label_column=_resolve_column_arg(dataset_args, "label_column", "label"),
             label_mode=dataset_args.get("label_mode", "auto"),
         )
+        _validate_hf_preprocessor_output(out[0], out[1], "sentence_similarity")
+        return out
 
     if hf_task == "fill_mask":
-        return preprocess_hf_text_fill_mask(
+        out = preprocess_hf_text_fill_mask(
             train,
             test,
             meta,
             hf_model_id=hf_model_id,
-            text_column=dataset_args.get("text_column", "text"),
+            text_column=_resolve_column_arg(dataset_args, "text_column", "text"),
             mlm_probability=dataset_args.get("mlm_probability", 0.15),
             label_pad_value=dataset_args.get("label_pad_value", -100),
         )
+        _validate_hf_preprocessor_output(out[0], out[1], "fill_mask")
+        return out
+
+    if hf_task in {"causal_lm", "causal_language_modeling", "causal_language_model"}:
+        out = preprocess_hf_text_causal_lm(
+            train,
+            test,
+            meta,
+            hf_model_id=hf_model_id,
+            prompt_column=_resolve_column_arg(dataset_args, "prompt_column"),
+            target_column=_resolve_column_arg(dataset_args, "target_column"),
+            text_column=_resolve_column_arg(dataset_args, "text_column"),
+            source_max_length=dataset_args.get("source_max_length"),
+            target_max_length=dataset_args.get("target_max_length"),
+            dynamic_padding=dataset_args.get("dynamic_padding", False),
+            label_pad_value=dataset_args.get("label_pad_value", -100),
+            label_strategy=dataset_args.get("label_strategy", "target_only"),
+        )
+        _validate_hf_preprocessor_output(out[0], out[1], "causal_lm")
+        return out
+
+    if hf_task in {"seq2seq", "text2text", "translation", "summarization"}:
+        out = preprocess_hf_text_seq2seq(
+            train,
+            test,
+            meta,
+            hf_model_id=hf_model_id,
+            source_column=_resolve_column_arg(dataset_args, "source_column"),
+            target_column=_resolve_column_arg(dataset_args, "target_column"),
+            source_max_length=dataset_args.get("source_max_length"),
+            target_max_length=dataset_args.get("target_max_length"),
+            dynamic_padding=dataset_args.get("dynamic_padding", False),
+            label_pad_value=dataset_args.get("label_pad_value", -100),
+        )
+        _validate_hf_preprocessor_output(out[0], out[1], "seq2seq")
+        return out
 
     raise ValueError(f"Unsupported HF text task: {hf_task}")

--- a/mlaas_data_generator/data/preprocessors/hf_text_generation.py
+++ b/mlaas_data_generator/data/preprocessors/hf_text_generation.py
@@ -1,0 +1,279 @@
+import numpy as np
+
+from .label_schema import attach_label_schema
+
+
+PROMPT_COLUMN_CANDIDATES = ("prompt", "instruction")
+TARGET_COLUMN_CANDIDATES = ("completion", "response", "output")
+SOURCE_COLUMN_CANDIDATES = ("source_text", "input")
+TARGET_TEXT_COLUMN_CANDIDATES = ("target_text", "label")
+TEXT_COLUMN_CANDIDATES = ("text",)
+
+
+def _pick_column(explicit_value, cols, candidates, column_role):
+    if explicit_value:
+        if explicit_value not in cols:
+            raise ValueError(f"Missing {column_role} '{explicit_value}'. Available={sorted(cols)}")
+        return explicit_value
+
+    for c in candidates:
+        if c in cols:
+            return c
+
+    raise ValueError(
+        f"Could not infer {column_role} from columns {sorted(cols)}. "
+        f"Set an explicit column_mapping/{column_role} in dataset args."
+    )
+
+
+def _load_tokenizer(hf_model_id):
+    try:
+        from transformers import AutoTokenizer
+    except Exception as e:
+        raise ImportError(
+            "HF generation preprocessing requires 'transformers'. Install with: pip install transformers"
+        ) from e
+
+    try:
+        tok = AutoTokenizer.from_pretrained(hf_model_id, use_fast=True)
+    except Exception:
+        tok = AutoTokenizer.from_pretrained(hf_model_id, use_fast=False)
+
+    if tok.pad_token_id is None:
+        tok.pad_token = tok.eos_token
+
+    return tok
+
+
+def _pad_sequences(rows, pad_value, dynamic_padding=False, max_length=None):
+    if not rows:
+        return np.zeros((0, 0), dtype="int32")
+
+    if dynamic_padding:
+        target_len = max(len(r) for r in rows)
+    else:
+        target_len = int(max_length) if max_length else max(len(r) for r in rows)
+
+    out = np.full((len(rows), target_len), int(pad_value), dtype="int32")
+    for i, row in enumerate(rows):
+        cur = row[:target_len]
+        out[i, : len(cur)] = np.asarray(cur, dtype="int32")
+    return out
+
+
+def _tokenize_texts(tokenizer, texts, max_length):
+    return tokenizer(
+        list(texts),
+        truncation=True,
+        max_length=int(max_length),
+        padding=False,
+        add_special_tokens=True,
+    )
+
+
+def preprocess_hf_text_causal_lm(
+    train,
+    test,
+    meta,
+    *,
+    hf_model_id,
+    prompt_column=None,
+    target_column=None,
+    text_column=None,
+    source_max_length=None,
+    target_max_length=None,
+    dynamic_padding=False,
+    label_pad_value=-100,
+    label_strategy="target_only",
+):
+    ds_train, _ = train
+    ds_test, _ = test
+
+    cols = set(ds_train.column_names)
+    tokenizer = _load_tokenizer(hf_model_id)
+
+    label_pad_value = int(label_pad_value)
+    source_max_length = int(source_max_length or meta.get("max_length", 128))
+    target_max_length = int(target_max_length or meta.get("max_length", 128))
+    dynamic_padding = bool(dynamic_padding)
+    label_strategy = str(label_strategy or "target_only").strip().lower()
+
+    resolved_text_column = None
+    resolved_prompt_column = None
+    resolved_target_column = None
+
+    if text_column:
+        resolved_text_column = _pick_column(text_column, cols, TEXT_COLUMN_CANDIDATES, "text_column")
+    elif prompt_column or target_column:
+        resolved_prompt_column = _pick_column(prompt_column, cols, PROMPT_COLUMN_CANDIDATES, "prompt_column")
+        resolved_target_column = _pick_column(target_column, cols, TARGET_COLUMN_CANDIDATES, "target_column")
+    else:
+        if any(c in cols for c in PROMPT_COLUMN_CANDIDATES) and any(c in cols for c in TARGET_COLUMN_CANDIDATES):
+            resolved_prompt_column = _pick_column(None, cols, PROMPT_COLUMN_CANDIDATES, "prompt_column")
+            resolved_target_column = _pick_column(None, cols, TARGET_COLUMN_CANDIDATES, "target_column")
+        else:
+            resolved_text_column = _pick_column(None, cols, TEXT_COLUMN_CANDIDATES, "text_column")
+
+    def _build_features(ds):
+        input_rows = []
+        label_rows = []
+
+        if resolved_text_column:
+            toks = _tokenize_texts(tokenizer, ds[resolved_text_column], max_length=source_max_length)
+            for token_ids in toks["input_ids"]:
+                ids = list(token_ids)
+                if label_strategy == "target_only":
+                    labels = list(ids)
+                elif label_strategy == "full_text":
+                    labels = list(ids)
+                else:
+                    raise ValueError("causal_lm label_strategy must be one of: target_only, full_text")
+
+                input_rows.append(ids)
+                label_rows.append(labels)
+
+        else:
+            prompt_tok = _tokenize_texts(tokenizer, ds[resolved_prompt_column], max_length=source_max_length)
+            target_tok = _tokenize_texts(tokenizer, ds[resolved_target_column], max_length=target_max_length)
+
+            eos_id = tokenizer.eos_token_id
+            for p_ids, t_ids in zip(prompt_tok["input_ids"], target_tok["input_ids"]):
+                p = list(p_ids)
+                t = list(t_ids)
+                if eos_id is not None and (not t or t[-1] != eos_id):
+                    t = t + [int(eos_id)]
+
+                merged = p + t
+                labels = ([label_pad_value] * len(p)) + list(t)
+                if label_strategy == "full_text":
+                    labels = list(merged)
+
+                input_rows.append(merged)
+                label_rows.append(labels)
+
+        input_ids = _pad_sequences(
+            input_rows,
+            pad_value=tokenizer.pad_token_id,
+            dynamic_padding=dynamic_padding,
+            max_length=(source_max_length + target_max_length),
+        )
+        attn_mask = (input_ids != int(tokenizer.pad_token_id)).astype("int32")
+
+        labels = _pad_sequences(
+            label_rows,
+            pad_value=label_pad_value,
+            dynamic_padding=dynamic_padding,
+            max_length=input_ids.shape[1],
+        )
+        labels[attn_mask == 0] = label_pad_value
+
+        return {"input_ids": input_ids, "attention_mask": attn_mask}, labels
+
+    X_train, y_train = _build_features(ds_train)
+    X_test, y_test = _build_features(ds_test)
+
+    max_input_len = int(X_train["input_ids"].shape[1]) if X_train["input_ids"].ndim == 2 else 0
+
+    meta2 = dict(meta)
+    meta2.update({
+        "hf_task": "causal_lm",
+        "modality": "text",
+        "x_format": "dict",
+        "x_keys": ["input_ids", "attention_mask"],
+        "label_granularity": "token",
+        "num_classes": int(getattr(tokenizer, "vocab_size", 0) or 0),
+        "label_pad_value": label_pad_value,
+        "hf_model_id": hf_model_id,
+        "source_max_length": source_max_length,
+        "target_max_length": target_max_length,
+        "dynamic_padding": dynamic_padding,
+        "label_strategy": label_strategy,
+        "input_shape": (max_input_len,),
+        "column_mapping": {
+            "text": resolved_text_column,
+            "prompt": resolved_prompt_column,
+            "target": resolved_target_column,
+        },
+        "hf_model_required": "AutoModelForCausalLM",
+    })
+
+    meta2 = attach_label_schema(meta2, y_train, default_num_labels=meta2["num_classes"], ignore_index=label_pad_value)
+    return (X_train, y_train), (X_test, y_test), meta2
+
+
+def preprocess_hf_text_seq2seq(
+    train,
+    test,
+    meta,
+    *,
+    hf_model_id,
+    source_column=None,
+    target_column=None,
+    source_max_length=None,
+    target_max_length=None,
+    dynamic_padding=False,
+    label_pad_value=-100,
+):
+    ds_train, _ = train
+    ds_test, _ = test
+
+    cols = set(ds_train.column_names)
+    tokenizer = _load_tokenizer(hf_model_id)
+
+    source_column = _pick_column(source_column, cols, SOURCE_COLUMN_CANDIDATES, "source_column")
+    target_column = _pick_column(target_column, cols, TARGET_TEXT_COLUMN_CANDIDATES, "target_column")
+
+    source_max_length = int(source_max_length or meta.get("max_length", 128))
+    target_max_length = int(target_max_length or meta.get("max_length", 128))
+    dynamic_padding = bool(dynamic_padding)
+    label_pad_value = int(label_pad_value)
+
+    def _build_features(ds):
+        src_tok = _tokenize_texts(tokenizer, ds[source_column], max_length=source_max_length)
+        tgt_tok = _tokenize_texts(tokenizer, ds[target_column], max_length=target_max_length)
+
+        input_ids = _pad_sequences(
+            src_tok["input_ids"],
+            pad_value=tokenizer.pad_token_id,
+            dynamic_padding=dynamic_padding,
+            max_length=source_max_length,
+        )
+        attention_mask = (input_ids != int(tokenizer.pad_token_id)).astype("int32")
+
+        target_ids = _pad_sequences(
+            tgt_tok["input_ids"],
+            pad_value=tokenizer.pad_token_id,
+            dynamic_padding=dynamic_padding,
+            max_length=target_max_length,
+        )
+        labels = target_ids.astype("int32")
+        labels[labels == int(tokenizer.pad_token_id)] = label_pad_value
+
+        return {"input_ids": input_ids, "attention_mask": attention_mask}, labels
+
+    X_train, y_train = _build_features(ds_train)
+    X_test, y_test = _build_features(ds_test)
+
+    meta2 = dict(meta)
+    meta2.update({
+        "hf_task": "seq2seq",
+        "modality": "text",
+        "x_format": "dict",
+        "x_keys": ["input_ids", "attention_mask"],
+        "label_granularity": "token",
+        "num_classes": int(getattr(tokenizer, "vocab_size", 0) or 0),
+        "label_pad_value": label_pad_value,
+        "hf_model_id": hf_model_id,
+        "source_max_length": source_max_length,
+        "target_max_length": target_max_length,
+        "dynamic_padding": dynamic_padding,
+        "input_shape": (int(X_train["input_ids"].shape[1]),),
+        "column_mapping": {
+            "source": source_column,
+            "target": target_column,
+        },
+        "hf_model_required": "AutoModelForSeq2SeqLM",
+    })
+
+    meta2 = attach_label_schema(meta2, y_train, default_num_labels=meta2["num_classes"], ignore_index=label_pad_value)
+    return (X_train, y_train), (X_test, y_test), meta2

--- a/mlaas_data_generator/models/adapters/hf_adapter.py
+++ b/mlaas_data_generator/models/adapters/hf_adapter.py
@@ -1,5 +1,12 @@
 from .hf_core import HFCore
-from .hf_task import SequenceClassificationSpec, SentenceSimilaritySpec, TokenClassificationSpec, FillMaskSpec
+from .hf_task import (
+    SequenceClassificationSpec,
+    SentenceSimilaritySpec,
+    TokenClassificationSpec,
+    FillMaskSpec,
+    CausalLMSpec,
+    Seq2SeqSpec,
+)
 import time
 
 
@@ -32,6 +39,12 @@ class TransformersTextFineTuneAdapter:
 
         elif hf_task == "fill_mask":
             spec = FillMaskSpec()
+
+        elif hf_task == "causal_lm":
+            spec = CausalLMSpec()
+
+        elif hf_task == "seq2seq":
+            spec = Seq2SeqSpec()
             
         else:
              spec = SequenceClassificationSpec(multilabel=multilabel, label_format=label_format)

--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -511,3 +511,71 @@ class FillMaskSpec(HFTaskSpec):
         acc = float((yp == yt).mean())
 
         return {"primary": acc, "secondary": np.nan}
+
+
+class CausalLMSpec(HFTaskSpec):
+    name = "causal_lm"
+    requires_num_labels = False
+
+    def build_model(self, transformers, model_id, num_labels):
+        AutoModel = transformers.AutoModelForCausalLM
+        self.weight_format = None
+        try:
+            model = AutoModel.from_pretrained(model_id, use_safetensors=True)
+            self.weight_format = "safetensors"
+        except OSError as e:
+            if "safetensors" in str(e).lower():
+                model = AutoModel.from_pretrained(model_id, use_safetensors=False)
+                self.weight_format = "pickle"
+            else:
+                raise
+        return model
+
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100):
+        if not isinstance(xb, dict):
+            enc = tokenizer(xb, truncation=True, padding=True, max_length=int(max_length), return_tensors="pt")
+            enc = {k: v.to(device) for k, v in enc.items()}
+        else:
+            enc = {k: torch.tensor(v, dtype=torch.long, device=device) for k, v in xb.items()}
+
+        labels_t = None
+        if yb is not None:
+            labels_t = torch.tensor(yb, dtype=torch.long, device=device)
+
+        return enc, labels_t, {"ignore_index": int(ignore_index)}
+
+    def loss_fn(self, torch, logits, labels_t, extra):
+        ignore_index = int(extra.get("ignore_index", -100))
+        return torch.nn.functional.cross_entropy(logits.transpose(1, 2), labels_t, ignore_index=ignore_index)
+
+    def preds_from_logits(self, torch, logits, extra):
+        return torch.argmax(logits, dim=-1)
+
+    def metrics(self, y_true, y_pred, y_extra=None):
+        ignore_index = int((y_extra or {}).get("ignore_index", -100))
+        y_true = np.asarray(y_true)
+        y_pred = np.asarray(y_pred)
+        mask = y_true != ignore_index
+        yt = y_true[mask]
+        yp = y_pred[mask]
+        if yt.size == 0:
+            return {"primary": np.nan, "secondary": np.nan}
+        return {"primary": float((yt == yp).mean()), "secondary": np.nan}
+
+
+class Seq2SeqSpec(CausalLMSpec):
+    name = "seq2seq"
+
+    def build_model(self, transformers, model_id, num_labels):
+        AutoModel = transformers.AutoModelForSeq2SeqLM
+        self.weight_format = None
+        try:
+            model = AutoModel.from_pretrained(model_id, use_safetensors=True)
+            self.weight_format = "safetensors"
+        except OSError as e:
+            if "safetensors" in str(e).lower():
+                model = AutoModel.from_pretrained(model_id, use_safetensors=False)
+                self.weight_format = "pickle"
+            else:
+                raise
+        return model

--- a/mlaas_data_generator/test/test_hf_generation_preprocessors.py
+++ b/mlaas_data_generator/test/test_hf_generation_preprocessors.py
@@ -1,0 +1,88 @@
+import numpy as np
+from unittest.mock import patch
+
+from mlaas_data_generator.data.preprocessors.hf import preprocess_hf
+
+
+class MiniDataset:
+    def __init__(self, rows):
+        self._rows = rows
+        self.column_names = list(rows.keys())
+        self.features = {k: None for k in self.column_names}
+
+    def __getitem__(self, key):
+        return self._rows[key]
+
+    def __len__(self):
+        first_col = self.column_names[0]
+        return len(self._rows[first_col])
+
+
+class DummyTokenizer:
+    pad_token_id = 0
+    eos_token_id = 2
+    eos_token = "</s>"
+    vocab_size = 256
+
+    def __call__(self, texts, truncation=True, max_length=16, padding=False, add_special_tokens=True):
+        if isinstance(texts, str):
+            texts = [texts]
+        ids = []
+        for txt in texts:
+            toks = [((ord(c) % 50) + 3) for c in str(txt)]
+            if add_special_tokens:
+                toks = toks[: max(0, max_length - 1)] + [self.eos_token_id]
+            else:
+                toks = toks[:max_length]
+            ids.append(toks)
+        return {"input_ids": ids}
+
+
+def _meta():
+    return {"hf_id": "dummy", "max_length": 12, "seed": 123, "modality": "text"}
+
+
+@patch("transformers.AutoTokenizer.from_pretrained", return_value=DummyTokenizer())
+def test_causal_lm_prompt_target_column_mapping(_):
+    train_ds = MiniDataset({"instruction": ["Hi", "Bye"], "output": ["there", "now"]})
+    test_ds = MiniDataset({"instruction": ["Go"], "output": ["home"]})
+
+    (train, test, meta2) = preprocess_hf(
+        (train_ds, None),
+        (test_ds, None),
+        {**_meta(), "hf_task": "causal_lm"},
+        hf_model_id="dummy-model",
+        column_mapping={"prompt_column": "instruction", "target_column": "output"},
+        source_max_length=8,
+        target_max_length=6,
+        dynamic_padding=True,
+    )
+
+    x_train, y_train = train
+    assert set(x_train.keys()) == {"input_ids", "attention_mask"}
+    assert x_train["input_ids"].shape == y_train.shape
+    assert np.any(y_train == -100), "prompt tokens should be masked for causal LM"
+    assert meta2["hf_task"] == "causal_lm"
+
+
+@patch("transformers.AutoTokenizer.from_pretrained", return_value=DummyTokenizer())
+def test_seq2seq_source_target_mapping_and_label_masking(_):
+    train_ds = MiniDataset({"input": ["question1", "question2"], "label": ["answer1", "answer2"]})
+    test_ds = MiniDataset({"input": ["question3"], "label": ["answer3"]})
+
+    (train, test, meta2) = preprocess_hf(
+        (train_ds, None),
+        (test_ds, None),
+        {**_meta(), "hf_task": "seq2seq"},
+        hf_model_id="dummy-model",
+        column_mapping={"source_column": "input", "target_column": "label"},
+        source_max_length=10,
+        target_max_length=7,
+    )
+
+    x_train, y_train = train
+    assert set(x_train.keys()) == {"input_ids", "attention_mask"}
+    assert y_train.ndim == 2
+    assert np.any(y_train == -100), "target padding should be masked"
+    assert meta2["column_mapping"]["source"] == "input"
+    assert meta2["column_mapping"]["target"] == "label"


### PR DESCRIPTION
### Motivation
- Extend the HF preprocessing pipeline to support generation tasks (causal language modeling and seq2seq) and avoid brittle hardcoded column assumptions.
- Provide explicit column mapping and long-form controls so generation datasets can be truncated/packed deterministically.
- Ensure downstream HF adapters and training code can consume dict-of-arrays loader outputs and token-aligned labels.

### Description
- Added new generation preprocessors in `mlaas_data_generator/data/preprocessors/hf_text_generation.py` implementing a causal LM preprocessor and a seq2seq preprocessor with schema fallbacks for prompt/response and source/target patterns, truncation/padding controls, dynamic padding, label masking and preserved `column_mapping` metadata.
- Extended the HF preprocessor dispatcher in `mlaas_data_generator/data/preprocessors/hf.py` to resolve column mappings via a `column_mapping` config, route to the new generation preprocessors (including common aliases), and validate produced batch keys against expected task keys.
- Added `CausalLMSpec` and `Seq2SeqSpec` to `mlaas_data_generator/models/adapters/hf_task.py` to support model construction (`AutoModelForCausalLM`, `AutoModelForSeq2SeqLM`), encoding, loss and metric behavior for token-level generation tasks.
- Wired the new specs into the fine-tune adapter in `mlaas_data_generator/models/adapters/hf_adapter.py` and added unit tests `mlaas_data_generator/test/test_hf_generation_preprocessors.py` that verify column mapping, masking of prompt tokens for causal LM, and target padding masking for seq2seq.

### Testing
- Compiled the modified Python files with `python -m py_compile` and the compilation succeeded for the changed modules.
- Ran `pytest -q mlaas_data_generator/test/test_hf_generation_preprocessors.py` but collection failed due to a missing runtime dependency (`numpy`) in the execution environment, so unit tests did not execute to completion.
- The new test file uses a patched `transformers.AutoTokenizer.from_pretrained` to validate tokenizer-dependent behaviors without external network calls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7b1611cc88330a9a18538f1871772)