### PR TITLE
Add HF generation preprocessors with explicit column mapping and validation

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -2,6 +2,49 @@ from .hf_text_sequence import preprocess_hf_text_sequence
 from .hf_text_similarity import preprocess_hf_text_similarity
 from .hf_text_fill_mask import preprocess_hf_text_fill_mask
 from .hf_text_token import preprocess_hf_text_token
+from .hf_text_generation import (
+    preprocess_hf_text_causal_lm_generation,
+    preprocess_hf_text_seq2seq_generation,
+)
+
+
+_EXPECTED_BATCH_KEYS = {
+    "sequence_classification": {"input_ids", "attention_mask"},
+    "token_classification": {"input_ids", "attention_mask"},
+    "sentence_similarity": {"input_ids", "attention_mask"},
+    "fill_mask": {"input_ids", "attention_mask"},
+    "causal_lm_generation": {"input_ids", "attention_mask"},
+    "seq2seq_generation": {"input_ids", "attention_mask"},
+}
+
+
+def _validate_hf_preprocessor_output(train, test, meta):
+    x_train, y_train = train
+    x_test, y_test = test
+    hf_task = str(meta.get("hf_task", "")).strip().lower().replace("-", "_")
+
+    if not isinstance(x_train, dict) or not isinstance(x_test, dict):
+        raise TypeError(f"HF task '{hf_task}' requires dict features; got {type(x_train)} / {type(x_test)}")
+
+    expected = _EXPECTED_BATCH_KEYS.get(hf_task, {"input_ids", "attention_mask"})
+    missing_train = sorted(expected - set(x_train.keys()))
+    missing_test = sorted(expected - set(x_test.keys()))
+    if missing_train or missing_test:
+        raise ValueError(
+            f"HF preprocessor output validation failed for task '{hf_task}'. "
+            f"Missing train keys={missing_train}, test keys={missing_test}."
+        )
+
+    if y_train is None or y_test is None:
+        raise ValueError(f"HF preprocessor output validation failed for task '{hf_task}': missing labels.")
+
+    if len(x_train["input_ids"]) != len(y_train) or len(x_test["input_ids"]) != len(y_test):
+        raise ValueError(
+            f"HF preprocessor output validation failed for task '{hf_task}': feature/label batch mismatch."
+        )
+
+    meta["x_keys"] = list(x_train.keys())
+    return train, test, meta
 
 def preprocess_hf(train, test, meta, **dataset_args):
     modality = meta.get("modality", "text")
@@ -17,23 +60,25 @@ def preprocess_hf(train, test, meta, **dataset_args):
         raise ValueError("HF preprocessing requires hf_model_id in dataset_args")
 
     if hf_task == "sequence_classification":
-        return preprocess_hf_text_sequence(
+        out = preprocess_hf_text_sequence(
             train, test, meta,
             hf_model_id=hf_model_id,
             text_column=dataset_args.get("text_column", "text"),
             label_column=dataset_args.get("label_column", "label"),
         )
+        return _validate_hf_preprocessor_output(*out)
 
     if hf_task == "token_classification":
-        return preprocess_hf_text_token(
+        out = preprocess_hf_text_token(
             train, test, meta,
             hf_model_id=hf_model_id,
             tokens_column=dataset_args.get("tokens_column") or dataset_args.get("text_column"),
             label_column=dataset_args.get("label_column"),
         )
+        return _validate_hf_preprocessor_output(*out)
     
     if hf_task == "sentence_similarity":
-        return preprocess_hf_text_similarity(
+        out = preprocess_hf_text_similarity(
             train,
             test,
             meta,
@@ -42,9 +87,10 @@ def preprocess_hf(train, test, meta, **dataset_args):
             label_column=dataset_args.get("label_column", "label"),
             label_mode=dataset_args.get("label_mode", "auto"),
         )
+        return _validate_hf_preprocessor_output(*out)
 
     if hf_task == "fill_mask":
-        return preprocess_hf_text_fill_mask(
+        out = preprocess_hf_text_fill_mask(
             train,
             test,
             meta,
@@ -53,13 +99,37 @@ def preprocess_hf(train, test, meta, **dataset_args):
             mlm_probability=dataset_args.get("mlm_probability", 0.15),
             label_pad_value=dataset_args.get("label_pad_value", -100),
         )
+        return _validate_hf_preprocessor_output(*out)
 
-    if hf_task in {"causal_lm_generation", "seq2seq_generation"}:
-        return preprocess_hf_text_sequence(
-            train, test, meta,
+    if hf_task == "causal_lm_generation":
+        out = preprocess_hf_text_causal_lm_generation(
+            train,
+            test,
+            meta,
             hf_model_id=hf_model_id,
-            text_column=dataset_args.get("text_column", "text"),
-            label_column=dataset_args.get("label_column", "label"),
+            column_mapping=dataset_args.get("column_mapping"),
+            max_length=dataset_args.get("max_length"),
+            source_max_length=dataset_args.get("source_max_length"),
+            target_max_length=dataset_args.get("target_max_length"),
+            prompt_loss_only=dataset_args.get("prompt_loss_only", True),
+            ignore_index=dataset_args.get("label_pad_value", -100),
+            dynamic_padding=dataset_args.get("dynamic_padding", False),
         )
+        return _validate_hf_preprocessor_output(*out)
+
+    if hf_task == "seq2seq_generation":
+        out = preprocess_hf_text_seq2seq_generation(
+            train,
+            test,
+            meta,
+            hf_model_id=hf_model_id,
+            column_mapping=dataset_args.get("column_mapping"),
+            max_length=dataset_args.get("max_length"),
+            source_max_length=dataset_args.get("source_max_length"),
+            target_max_length=dataset_args.get("target_max_length"),
+            ignore_index=dataset_args.get("label_pad_value", -100),
+            dynamic_padding=dataset_args.get("dynamic_padding", False),
+        )
+        return _validate_hf_preprocessor_output(*out)
 
     raise ValueError(f"Unsupported HF text task: {hf_task}")

--- a/mlaas_data_generator/data/preprocessors/hf_text_generation.py
+++ b/mlaas_data_generator/data/preprocessors/hf_text_generation.py
@@ -1,0 +1,265 @@
+import numpy as np
+
+
+def _first_existing(columns, candidates):
+    for name in candidates:
+        if name in columns:
+            return name
+    return None
+
+
+def resolve_generation_columns(ds_train, *, column_mapping=None, hf_task="causal_lm_generation"):
+    cols = set(ds_train.column_names)
+    mapping = dict(column_mapping or {})
+
+    if hf_task == "seq2seq_generation":
+        source_col = mapping.get("source") or _first_existing(cols, [
+            "source_text", "input", "prompt", "instruction", "text", "source",
+        ])
+        target_col = mapping.get("target") or _first_existing(cols, [
+            "target_text", "label", "output", "completion", "response", "target",
+        ])
+    else:
+        prompt_col = mapping.get("prompt") or _first_existing(cols, [
+            "prompt", "instruction", "input", "source_text", "text", "source",
+        ])
+        target_col = mapping.get("target") or _first_existing(cols, [
+            "completion", "response", "output", "target_text", "label", "target",
+        ])
+        source_col = prompt_col
+
+    if not source_col:
+        raise ValueError(
+            f"Could not resolve source/prompt column for task '{hf_task}'. "
+            f"Provide dataset_args.column_mapping. Available columns: {sorted(cols)}"
+        )
+    if not target_col:
+        raise ValueError(
+            f"Could not resolve target column for task '{hf_task}'. "
+            f"Provide dataset_args.column_mapping. Available columns: {sorted(cols)}"
+        )
+
+    return {"source": source_col, "target": target_col}
+
+
+def _to_text_list(values):
+    out = []
+    for v in values:
+        if v is None:
+            out.append("")
+        else:
+            out.append(str(v))
+    return out
+
+
+def _pad_encodings(enc, pad_to):
+    input_ids = enc["input_ids"]
+    attention_mask = enc["attention_mask"]
+    padded_ids = []
+    padded_mask = []
+    for ids, mask in zip(input_ids, attention_mask):
+        ids = list(ids)[:pad_to]
+        mask = list(mask)[:pad_to]
+        pad_len = max(0, pad_to - len(ids))
+        padded_ids.append(ids + [0] * pad_len)
+        padded_mask.append(mask + [0] * pad_len)
+    return np.asarray(padded_ids, dtype="int32"), np.asarray(padded_mask, dtype="int32")
+
+
+def preprocess_hf_text_causal_lm_generation(
+    train,
+    test,
+    meta,
+    *,
+    hf_model_id,
+    column_mapping=None,
+    max_length=None,
+    source_max_length=None,
+    target_max_length=None,
+    prompt_loss_only=True,
+    ignore_index=-100,
+    dynamic_padding=False,
+):
+    ds_train, _ = train
+    ds_test, _ = test
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(hf_model_id, use_fast=True)
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    resolved = resolve_generation_columns(ds_train, column_mapping=column_mapping, hf_task="causal_lm_generation")
+    prompt_col, target_col = resolved["source"], resolved["target"]
+
+    max_len = int(max_length or meta.get("max_length", 512))
+    src_max = int(source_max_length or max_len)
+    tgt_max = int(target_max_length or max_len)
+
+    def _encode_split(ds):
+        prompts = _to_text_list(ds[prompt_col])
+        targets = _to_text_list(ds[target_col])
+
+        p_tok = tokenizer(prompts, truncation=True, padding=False, max_length=src_max, add_special_tokens=True)
+        t_tok = tokenizer(targets, truncation=True, padding=False, max_length=tgt_max, add_special_tokens=False)
+
+        pad_id = int(tokenizer.pad_token_id)
+        eos_id = int(tokenizer.eos_token_id if tokenizer.eos_token_id is not None else pad_id)
+
+        ids_list, mask_list, label_list = [], [], []
+        for p_ids, t_ids in zip(p_tok["input_ids"], t_tok["input_ids"]):
+            full_ids = (list(p_ids) + list(t_ids) + [eos_id])[:max_len]
+            labels = full_ids.copy()
+            if prompt_loss_only:
+                prompt_len = min(len(p_ids), len(full_ids))
+                labels[:prompt_len] = [int(ignore_index)] * prompt_len
+
+            ids_list.append(full_ids)
+            mask_list.append([1] * len(full_ids))
+            label_list.append(labels)
+
+        pad_to = max(len(x) for x in ids_list) if dynamic_padding else max_len
+        padded_ids, padded_mask, padded_labels = [], [], []
+        for ids, mask, labels in zip(ids_list, mask_list, label_list):
+            ids = ids[:pad_to]
+            mask = mask[:pad_to]
+            labels = labels[:pad_to]
+            pad_len = max(0, pad_to - len(ids))
+            padded_ids.append(ids + [pad_id] * pad_len)
+            padded_mask.append(mask + [0] * pad_len)
+            padded_labels.append(labels + [int(ignore_index)] * pad_len)
+
+        X = {
+            "input_ids": np.asarray(padded_ids, dtype="int32"),
+            "attention_mask": np.asarray(padded_mask, dtype="int32"),
+        }
+        y = np.asarray(padded_labels, dtype="int32")
+        return X, y, pad_to
+
+    X_train, y_train, train_len = _encode_split(ds_train)
+    X_test, y_test, test_len = _encode_split(ds_test)
+
+    pad_len = max(train_len, test_len) if dynamic_padding else max_len
+    if dynamic_padding and train_len != test_len:
+        # keep shapes aligned for downstream tensorization consistency
+        X_train["input_ids"], X_train["attention_mask"] = _pad_encodings(X_train, pad_len)
+        X_test["input_ids"], X_test["attention_mask"] = _pad_encodings(X_test, pad_len)
+        y_train = np.pad(y_train, ((0, 0), (0, pad_len - y_train.shape[1])), constant_values=int(ignore_index))
+        y_test = np.pad(y_test, ((0, 0), (0, pad_len - y_test.shape[1])), constant_values=int(ignore_index))
+
+    meta2 = dict(meta)
+    meta2.update({
+        "hf_task": "causal_lm_generation",
+        "hf_model_id": hf_model_id,
+        "x_format": "dict",
+        "x_keys": list(X_train.keys()),
+        "input_shape": (pad_len,),
+        "label_granularity": "token",
+        "modality": "text",
+        "num_classes": int(meta.get("num_classes", 1) or 1),
+        "column_mapping": {"prompt": prompt_col, "target": target_col},
+        "prompt_loss_only": bool(prompt_loss_only),
+        "ignore_index": int(ignore_index),
+        "source_max_length": src_max,
+        "target_max_length": tgt_max,
+        "dynamic_padding": bool(dynamic_padding),
+    })
+    return (X_train, y_train), (X_test, y_test), meta2
+
+
+def preprocess_hf_text_seq2seq_generation(
+    train,
+    test,
+    meta,
+    *,
+    hf_model_id,
+    column_mapping=None,
+    max_length=None,
+    source_max_length=None,
+    target_max_length=None,
+    ignore_index=-100,
+    dynamic_padding=False,
+):
+    ds_train, _ = train
+    ds_test, _ = test
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(hf_model_id, use_fast=True)
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    resolved = resolve_generation_columns(ds_train, column_mapping=column_mapping, hf_task="seq2seq_generation")
+    source_col, target_col = resolved["source"], resolved["target"]
+
+    max_len = int(max_length or meta.get("max_length", 512))
+    src_max = int(source_max_length or max_len)
+    tgt_max = int(target_max_length or max_len)
+
+    def _encode_split(ds):
+        src = _to_text_list(ds[source_col])
+        tgt = _to_text_list(ds[target_col])
+
+        source_enc = tokenizer(src, truncation=True, padding=False, max_length=src_max, return_attention_mask=True)
+        target_enc = tokenizer(text_target=tgt, truncation=True, padding=False, max_length=tgt_max, return_attention_mask=False)
+
+        src_pad_to = max(len(x) for x in source_enc["input_ids"]) if dynamic_padding else src_max
+        tgt_pad_to = max(len(x) for x in target_enc["input_ids"]) if dynamic_padding else tgt_max
+
+        pad_id = int(tokenizer.pad_token_id)
+
+        X_ids, X_mask, y = [], [], []
+        for s_ids, s_mask, t_ids in zip(source_enc["input_ids"], source_enc["attention_mask"], target_enc["input_ids"]):
+            s_ids = list(s_ids)[:src_pad_to]
+            s_mask = list(s_mask)[:src_pad_to]
+            t_ids = list(t_ids)[:tgt_pad_to]
+
+            s_pad = max(0, src_pad_to - len(s_ids))
+            t_pad = max(0, tgt_pad_to - len(t_ids))
+
+            X_ids.append(s_ids + [pad_id] * s_pad)
+            X_mask.append(s_mask + [0] * s_pad)
+            y.append(t_ids + [int(ignore_index)] * t_pad)
+
+        X = {
+            "input_ids": np.asarray(X_ids, dtype="int32"),
+            "attention_mask": np.asarray(X_mask, dtype="int32"),
+        }
+        labels = np.asarray(y, dtype="int32")
+        return X, labels, src_pad_to, tgt_pad_to
+
+    X_train, y_train, train_src_len, train_tgt_len = _encode_split(ds_train)
+    X_test, y_test, test_src_len, test_tgt_len = _encode_split(ds_test)
+
+    src_pad_to = max(train_src_len, test_src_len) if dynamic_padding else src_max
+    tgt_pad_to = max(train_tgt_len, test_tgt_len) if dynamic_padding else tgt_max
+    if dynamic_padding:
+        if X_train["input_ids"].shape[1] != src_pad_to:
+            X_train["input_ids"], X_train["attention_mask"] = _pad_encodings(X_train, src_pad_to)
+        if X_test["input_ids"].shape[1] != src_pad_to:
+            X_test["input_ids"], X_test["attention_mask"] = _pad_encodings(X_test, src_pad_to)
+
+        if y_train.shape[1] != tgt_pad_to:
+            y_train = np.pad(y_train, ((0, 0), (0, tgt_pad_to - y_train.shape[1])), constant_values=int(ignore_index))
+        if y_test.shape[1] != tgt_pad_to:
+            y_test = np.pad(y_test, ((0, 0), (0, tgt_pad_to - y_test.shape[1])), constant_values=int(ignore_index))
+
+    meta2 = dict(meta)
+    meta2.update({
+        "hf_task": "seq2seq_generation",
+        "hf_model_id": hf_model_id,
+        "x_format": "dict",
+        "x_keys": list(X_train.keys()),
+        "input_shape": (src_pad_to,),
+        "label_granularity": "token",
+        "modality": "text",
+        "num_classes": int(meta.get("num_classes", 1) or 1),
+        "column_mapping": {"source": source_col, "target": target_col},
+        "ignore_index": int(ignore_index),
+        "source_max_length": src_max,
+        "target_max_length": tgt_max,
+        "dynamic_padding": bool(dynamic_padding),
+        "target_shape": (tgt_pad_to,),
+    })
+
+    return (X_train, y_train), (X_test, y_test), meta2

--- a/mlaas_data_generator/test/test_hf_generation_preprocessors.py
+++ b/mlaas_data_generator/test/test_hf_generation_preprocessors.py
@@ -1,0 +1,108 @@
+import sys
+import types
+
+import numpy as np
+
+from mlaas_data_generator.data.preprocessors.hf import preprocess_hf
+
+
+class DummySplit:
+    def __init__(self, rows):
+        self._rows = rows
+        self.column_names = list(rows[0].keys()) if rows else []
+
+    def __getitem__(self, key):
+        return [r.get(key) for r in self._rows]
+
+
+class FakeTokenizer:
+    pad_token_id = 0
+    eos_token_id = 2
+    pad_token = "<pad>"
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+
+    def _encode_one(self, text):
+        base = [min(50, max(3, len(tok))) for tok in str(text).split()]
+        return base or [3]
+
+    def __call__(self, texts=None, text_target=None, truncation=True, padding=False, max_length=8, add_special_tokens=True, return_attention_mask=True, **kwargs):
+        seqs = text_target if text_target is not None else texts
+        if isinstance(seqs, str):
+            seqs = [seqs]
+        ids = []
+        masks = []
+        for t in seqs:
+            token_ids = self._encode_one(t)
+            if add_special_tokens:
+                token_ids = [1] + token_ids
+            token_ids = token_ids[: int(max_length)]
+            ids.append(token_ids)
+            masks.append([1] * len(token_ids))
+        out = {"input_ids": ids}
+        if return_attention_mask:
+            out["attention_mask"] = masks
+        return out
+
+
+def _install_fake_transformers():
+    fake_mod = types.SimpleNamespace(AutoTokenizer=FakeTokenizer)
+    sys.modules["transformers"] = fake_mod
+
+
+def test_causal_lm_generation_preprocessor_prompt_completion_mapping():
+    _install_fake_transformers()
+    train_rows = [
+        {"prompt": "Write a haiku", "completion": "Soft rain at dusk"},
+        {"prompt": "Translate hello", "completion": "bonjour"},
+    ]
+    test_rows = [{"prompt": "Say hi", "completion": "hi"}]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "causal_lm_generation", "modality": "text", "max_length": 12, "hf_id": "dummy"},
+        hf_model_id="dummy/model",
+        source_max_length=6,
+        target_max_length=6,
+        dynamic_padding=True,
+    )
+
+    x_train, y_train = train
+    assert set(x_train.keys()) >= {"input_ids", "attention_mask"}
+    assert x_train["input_ids"].shape == y_train.shape
+    assert meta["column_mapping"]["prompt"] == "prompt"
+    assert meta["column_mapping"]["target"] == "completion"
+
+
+def test_seq2seq_generation_preprocessor_source_target_mapping():
+    _install_fake_transformers()
+    train_rows = [
+        {"source_text": "summarize this long article", "target_text": "short summary"},
+        {"source_text": "another source", "target_text": "target output"},
+    ]
+    test_rows = [{"source_text": "src", "target_text": "tgt"}]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "seq2seq_generation", "modality": "text", "max_length": 10, "hf_id": "dummy"},
+        hf_model_id="dummy/model",
+        source_max_length=7,
+        target_max_length=5,
+        dynamic_padding=True,
+    )
+
+    x_train, y_train = train
+    x_test, y_test = test
+
+    assert set(x_train.keys()) >= {"input_ids", "attention_mask"}
+    assert x_train["input_ids"].shape[1] <= 7
+    assert y_train.shape[1] <= 5
+    assert x_train["input_ids"].shape[0] == y_train.shape[0]
+    assert x_test["input_ids"].shape[0] == y_test.shape[0]
+    assert np.any(y_train == -100)
+    assert meta["column_mapping"]["source"] == "source_text"
+    assert meta["column_mapping"]["target"] == "target_text"


### PR DESCRIPTION
### Motivation
- Add first-class support for generation tasks (causal LM and seq2seq) in the HF preprocessing pipeline and avoid brittle, hardcoded column assumptions for prompt/response and source/target schemas. 
- Provide controls for truncation/packing for long-form generation (`source_max_length`, `target_max_length`, `dynamic_padding`, `prompt_loss_only`) and ensure loader outputs match downstream task expectations.

### Description
- Added a new module `mlaas_data_generator/data/preprocessors/hf_text_generation.py` implementing `preprocess_hf_text_causal_lm_generation` and `preprocess_hf_text_seq2seq_generation` that tokenize source/prompt and target separately and produce token-level `labels` suitable for HF generation objectives. 
- Extended the HF dispatcher in `mlaas_data_generator/data/preprocessors/hf.py` to import and route generation tasks to the new preprocessors and to accept explicit `dataset_args` such as `column_mapping`, `source_max_length`, `target_max_length`, `dynamic_padding`, and `prompt_loss_only`. 
- Added explicit column-resolution logic to recognise common schema patterns (e.g. `prompt`/`completion`/`instruction`/`output` and `source_text`/`target_text`/`input`/`label`) and to allow overrides via `column_mapping`. 
- Added centralized output validation (`_validate_hf_preprocessor_output`) and an `_EXPECTED_BATCH_KEYS` mapping in `preprocess_hf` to enforce that preprocessors emit the expected keys (e.g. `input_ids`, `attention_mask`) and that feature/label lengths align; metadata keys like `column_mapping`, `x_keys`, `input_shape`, and `ignore_index` are populated for downstream use. 
- Added unit tests `mlaas_data_generator/test/test_hf_generation_preprocessors.py` that use a lightweight mocked tokenizer and dummy splits to validate mapping, shapes, masking, and `column_mapping` behaviour.

### Testing
- `python -m compileall mlaas_data_generator/data/preprocessors/hf.py mlaas_data_generator/data/preprocessors/hf_text_generation.py mlaas_data_generator/test/test_hf_generation_preprocessors.py` succeeded and the modified modules compile cleanly. 
- Running the new unit tests with `pytest -q mlaas_data_generator/test/test_hf_generation_preprocessors.py` failed during collection in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'numpy'`), so the tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d519b41c83308f12a1fbf9925ca3)