### PR TITLE
Add Hugging Face image modality routing and image-aware preprocessing

### DIFF
--- a/mlaas_data_generator/data/master_loader.py
+++ b/mlaas_data_generator/data/master_loader.py
@@ -15,6 +15,7 @@ from .preprocessors.hf import preprocess_hf
 PREPROCESSOR_REGISTRY = {
     "tabular_scaling": preprocess_tabular_scaling,
     "image_float01": preprocess_image_float01,
+    "hf": preprocess_hf,
     "hf_text": preprocess_hf,
 }
 
@@ -94,7 +95,7 @@ def load_dataset(name, **kwargs):
         # Default: HF text preprocessor always tokenises
         if preprocessors is None:
             preprocessors = [{
-                "name": "hf_text",
+                "name": "hf",
                 "args": {k: v for k, v in kwargs.items() if k != "preprocessors"},
             }]
 

--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -6,6 +6,7 @@ from .hf_text_generation import (
     preprocess_hf_text_causal_lm_generation,
     preprocess_hf_text_seq2seq_generation,
 )
+from .hf_image import preprocess_hf_image
 
 
 _EXPECTED_BATCH_KEYS = {
@@ -15,6 +16,9 @@ _EXPECTED_BATCH_KEYS = {
     "fill_mask": {"input_ids", "attention_mask"},
     "causal_lm_generation": {"input_ids", "attention_mask"},
     "seq2seq_generation": {"input_ids", "attention_mask"},
+    "image_classification": {"pixel_values"},
+    "image_detection": {"pixel_values"},
+    "image_segmentation": {"pixel_values"},
 }
 
 
@@ -38,7 +42,9 @@ def _validate_hf_preprocessor_output(train, test, meta):
     if y_train is None or y_test is None:
         raise ValueError(f"HF preprocessor output validation failed for task '{hf_task}': missing labels.")
 
-    if len(x_train["input_ids"]) != len(y_train) or len(x_test["input_ids"]) != len(y_test):
+    train_count = len(next(iter(x_train.values())))
+    test_count = len(next(iter(x_test.values())))
+    if train_count != len(y_train) or test_count != len(y_test):
         raise ValueError(
             f"HF preprocessor output validation failed for task '{hf_task}': feature/label batch mismatch."
         )
@@ -46,18 +52,41 @@ def _validate_hf_preprocessor_output(train, test, meta):
     meta["x_keys"] = list(x_train.keys())
     return train, test, meta
 
+
 def preprocess_hf(train, test, meta, **dataset_args):
-    modality = meta.get("modality", "text")
+    modality = str(meta.get("modality", "text")).strip().lower()
     hf_task = str(meta.get("hf_task", "sequence_classification")).strip().lower().replace("-", "_")
     if hf_task in {"mlm", "masked_lm"}:
         hf_task = "fill_mask"
 
-    if modality != "text":
-        raise NotImplementedError(f"HF modality '{modality}' not implemented")
-
     hf_model_id = dataset_args.get("hf_model_id")
     if not hf_model_id:
         raise ValueError("HF preprocessing requires hf_model_id in dataset_args")
+
+    if modality == "image":
+        task_type = str(meta.get("task_type", "classification")).strip().lower()
+        hf_task = f"image_{task_type}"
+        meta["hf_task"] = hf_task
+        out = preprocess_hf_image(
+            train,
+            test,
+            meta,
+            hf_model_id=hf_model_id,
+            image_column=dataset_args.get("image_column", "image"),
+            label_column=dataset_args.get("label_column", "label"),
+            boxes_column=dataset_args.get("boxes_column"),
+            classes_column=dataset_args.get("classes_column"),
+            mask_column=dataset_args.get("mask_column"),
+            task_type=task_type,
+            training_augmentations=dataset_args.get("training_augmentations", True),
+            eval_augmentations=dataset_args.get("eval_augmentations", False),
+            on_decode_error=dataset_args.get("on_decode_error", "skip"),
+            report_decode_errors=dataset_args.get("report_decode_errors", True),
+        )
+        return _validate_hf_preprocessor_output(*out)
+
+    if modality != "text":
+        raise NotImplementedError(f"HF modality '{modality}' not implemented")
 
     if hf_task == "sequence_classification":
         out = preprocess_hf_text_sequence(
@@ -76,7 +105,7 @@ def preprocess_hf(train, test, meta, **dataset_args):
             label_column=dataset_args.get("label_column"),
         )
         return _validate_hf_preprocessor_output(*out)
-    
+
     if hf_task == "sentence_similarity":
         out = preprocess_hf_text_similarity(
             train,

--- a/mlaas_data_generator/data/preprocessors/hf_image.py
+++ b/mlaas_data_generator/data/preprocessors/hf_image.py
@@ -1,0 +1,240 @@
+import io
+import os
+
+import numpy as np
+
+
+def _to_numpy_rgb(image_like):
+    if image_like is None:
+        raise ValueError("image is None")
+
+    if isinstance(image_like, np.ndarray):
+        arr = image_like
+    elif isinstance(image_like, dict):
+        if "array" in image_like and image_like["array"] is not None:
+            arr = np.asarray(image_like["array"])
+        elif "bytes" in image_like and image_like["bytes"] is not None:
+            data = image_like["bytes"]
+            arr = _decode_bytes(data)
+        elif "path" in image_like and image_like["path"]:
+            arr = _decode_path(image_like["path"])
+        else:
+            raise ValueError("unsupported HF image dict payload")
+    elif isinstance(image_like, (bytes, bytearray)):
+        arr = _decode_bytes(image_like)
+    elif isinstance(image_like, str):
+        arr = _decode_path(image_like)
+    else:
+        raise TypeError(f"unsupported image payload type={type(image_like)}")
+
+    arr = np.asarray(arr)
+    if arr.ndim == 2:
+        arr = np.stack([arr, arr, arr], axis=-1)
+    if arr.ndim != 3:
+        raise ValueError(f"expected HWC image with ndim=3, got shape={arr.shape}")
+
+    if arr.shape[-1] == 1:
+        arr = np.repeat(arr, 3, axis=-1)
+    elif arr.shape[-1] == 4:
+        arr = arr[..., :3]
+    elif arr.shape[-1] != 3:
+        raise ValueError(f"expected channel-last with 1/3/4 channels, got shape={arr.shape}")
+
+    return arr
+
+
+def _decode_path(path):
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    try:
+        from PIL import Image
+    except Exception as e:
+        raise ImportError("Image decoding from path requires Pillow") from e
+    with Image.open(path) as im:
+        return np.asarray(im.convert("RGB"))
+
+
+def _decode_bytes(data):
+    try:
+        from PIL import Image
+    except Exception as e:
+        raise ImportError("Image decoding from bytes requires Pillow") from e
+    with Image.open(io.BytesIO(data)) as im:
+        return np.asarray(im.convert("RGB"))
+
+
+def _normalise_detection_item(boxes, classes):
+    if boxes is None:
+        boxes = []
+    if classes is None:
+        classes = []
+    out_boxes = np.asarray(boxes, dtype=np.float32)
+    out_classes = np.asarray(classes, dtype=np.int64)
+    if out_boxes.size == 0:
+        out_boxes = np.zeros((0, 4), dtype=np.float32)
+    elif out_boxes.ndim == 1:
+        if out_boxes.shape[0] != 4:
+            raise ValueError("detection boxes must be Nx4")
+        out_boxes = out_boxes.reshape(1, 4)
+    elif out_boxes.ndim != 2 or out_boxes.shape[1] != 4:
+        raise ValueError(f"detection boxes must be Nx4, got shape={out_boxes.shape}")
+    return {"boxes": out_boxes, "classes": out_classes}
+
+
+def _process_split(
+    ds,
+    *,
+    image_processor,
+    image_column,
+    task_type,
+    training,
+    label_column=None,
+    boxes_column=None,
+    classes_column=None,
+    mask_column=None,
+    on_decode_error="skip",
+    report_decode_errors=False,
+):
+    images = []
+    labels = []
+    decode_errors = []
+
+    for idx in range(len(ds)):
+        row = ds[idx]
+        try:
+            image = _to_numpy_rgb(row.get(image_column))
+            proc = image_processor(
+                image,
+                return_tensors=None,
+                do_resize=True,
+                do_normalize=True,
+                do_augment=bool(training),
+            )
+            pix = proc.get("pixel_values", proc)
+            pix = np.asarray(pix, dtype=np.float32)
+            if pix.ndim == 4:
+                pix = pix[0]
+            if pix.ndim != 3:
+                raise ValueError(f"processor output must be CHW/HWC 3D, got {pix.shape}")
+            if pix.shape[0] != 3 and pix.shape[-1] == 3:
+                pix = np.transpose(pix, (2, 0, 1))
+            if pix.shape[0] != 3:
+                raise ValueError(f"processor output must have 3 channels, got {pix.shape}")
+        except Exception as e:
+            decode_errors.append({"index": idx, "error": str(e)})
+            if on_decode_error == "raise":
+                raise
+            if on_decode_error == "report":
+                images.append(None)
+                labels.append(None)
+            continue
+
+        images.append(pix)
+
+        if task_type == "classification":
+            labels.append(int(row.get(label_column)))
+        elif task_type == "detection":
+            labels.append(_normalise_detection_item(row.get(boxes_column), row.get(classes_column)))
+        elif task_type == "segmentation":
+            mask = row.get(mask_column)
+            if mask is None:
+                raise ValueError("segmentation mask is missing")
+            labels.append(np.asarray(mask))
+        else:
+            labels.append(None)
+
+    x = {"pixel_values": np.asarray(images, dtype=np.float32)} if on_decode_error != "report" else {"pixel_values": images}
+    if task_type == "classification":
+        y = np.asarray(labels, dtype=np.int64)
+    else:
+        y = labels
+
+    report = {"total": len(ds), "failed": len(decode_errors)}
+    if report_decode_errors:
+        report["errors"] = decode_errors
+    return x, y, report
+
+
+def preprocess_hf_image(
+    train,
+    test,
+    meta,
+    *,
+    hf_model_id,
+    image_column="image",
+    label_column="label",
+    boxes_column=None,
+    classes_column=None,
+    mask_column=None,
+    task_type=None,
+    training_augmentations=True,
+    eval_augmentations=False,
+    on_decode_error="skip",
+    report_decode_errors=False,
+):
+    try:
+        from transformers import AutoImageProcessor
+    except Exception as e:
+        raise ImportError("HF image preprocessing requires transformers[vision]") from e
+
+    if on_decode_error not in {"skip", "raise", "report"}:
+        raise ValueError("on_decode_error must be one of ['skip', 'raise', 'report']")
+
+    ds_train, _ = train
+    ds_test, _ = test
+    task_type = (task_type or meta.get("task_type", "classification")).strip().lower()
+
+    processor = AutoImageProcessor.from_pretrained(hf_model_id)
+
+    x_train, y_train, train_report = _process_split(
+        ds_train,
+        image_processor=processor,
+        image_column=image_column,
+        task_type=task_type,
+        training=bool(training_augmentations),
+        label_column=label_column,
+        boxes_column=boxes_column,
+        classes_column=classes_column,
+        mask_column=mask_column,
+        on_decode_error=on_decode_error,
+        report_decode_errors=report_decode_errors,
+    )
+    x_test, y_test, test_report = _process_split(
+        ds_test,
+        image_processor=processor,
+        image_column=image_column,
+        task_type=task_type,
+        training=bool(eval_augmentations),
+        label_column=label_column,
+        boxes_column=boxes_column,
+        classes_column=classes_column,
+        mask_column=mask_column,
+        on_decode_error=on_decode_error,
+        report_decode_errors=report_decode_errors,
+    )
+
+    meta.update(
+        {
+            "image_column": image_column,
+            "label_column": label_column,
+            "boxes_column": boxes_column,
+            "classes_column": classes_column,
+            "mask_column": mask_column,
+            "task_type": task_type,
+            "modality": "image",
+            "hf_processor": hf_model_id,
+            "channel_order": "CHW",
+            "training_augmentations": bool(training_augmentations),
+            "eval_augmentations": bool(eval_augmentations),
+            "decode_error_policy": on_decode_error,
+            "decode_report": {"train": train_report, "test": test_report},
+            "schema": {
+                "image_column": image_column,
+                "label_column": label_column if task_type == "classification" else None,
+                "detection": {"boxes_column": boxes_column, "classes_column": classes_column},
+                "segmentation": {"mask_column": mask_column},
+            },
+        }
+    )
+
+    return (x_train, y_train), (x_test, y_test), meta

--- a/mlaas_data_generator/data/sources/huggingface.py
+++ b/mlaas_data_generator/data/sources/huggingface.py
@@ -20,7 +20,9 @@ def load_huggingface_source(**kwargs):
     max_length = int(kwargs.get("max_length", 128))
 
     task_type = kwargs.get("task", "classification")
-    modality = kwargs.get("modality", "text")
+    modality = str(kwargs.get("modality", "text")).strip().lower()
+    if modality not in {"text", "image"}:
+        raise ValueError(f"Unsupported HF modality '{modality}'. Expected one of ['text', 'image']")
     hf_task = kwargs.get("hf_task", "sequence_classification")
 
     ds_train = load_dataset(dataset_name, dataset_config, split=train_split)
@@ -66,6 +68,47 @@ def load_huggingface_source(**kwargs):
         ds_train = ds_train.select(range(min(n, len(ds_train))))
         ds_test = ds_test.select(range(min(max(1, n // 5), len(ds_test))))
 
+    schema = None
+    if modality == "image":
+        image_column = kwargs.get("image_column", "image")
+        label_column = kwargs.get("label_column", "label")
+        boxes_column = kwargs.get("boxes_column")
+        classes_column = kwargs.get("classes_column")
+        mask_column = kwargs.get("mask_column")
+
+        train_cols = set(getattr(ds_train, "column_names", []) or [])
+        if image_column not in train_cols:
+            raise ValueError(
+                f"HF image modality requires image_column '{image_column}' to exist in dataset '{dataset_name}'. "
+                f"Available columns: {sorted(train_cols)}"
+            )
+
+        schema = {
+            "image_column": image_column,
+            "label_column": label_column if label_column in train_cols else None,
+            "detection": {
+                "boxes_column": boxes_column if boxes_column in train_cols else None,
+                "classes_column": classes_column if classes_column in train_cols else None,
+            },
+            "segmentation": {
+                "mask_column": mask_column if mask_column in train_cols else None,
+            },
+        }
+
+        if task_type == "classification" and schema["label_column"] is None:
+            raise ValueError(
+                f"HF image classification requires label_column '{label_column}'. "
+                f"Available columns: {sorted(train_cols)}"
+            )
+
+        if task_type == "detection":
+            missing = [c for c in (boxes_column, classes_column) if c and c not in train_cols]
+            if missing:
+                raise ValueError(f"HF image detection requested columns not found: {missing}")
+
+        if task_type == "segmentation" and mask_column and mask_column not in train_cols:
+            raise ValueError(f"HF image segmentation mask_column '{mask_column}' not found in dataset")
+
     dataset_args = dict(kwargs)
     dataset_args.pop("preprocessors", None)
 
@@ -80,6 +123,7 @@ def load_huggingface_source(**kwargs):
         "task_type": task_type,
         "modality": modality,
         "hf_task": hf_task,
+        "schema": schema,
         "dataset_args": dataset_args,
     }
 

--- a/mlaas_data_generator/test/test_hf_image_preprocessor.py
+++ b/mlaas_data_generator/test/test_hf_image_preprocessor.py
@@ -1,0 +1,116 @@
+import sys
+import types
+
+import numpy as np
+
+from mlaas_data_generator.data.preprocessors.hf import preprocess_hf
+
+
+class DummySplit:
+    def __init__(self, rows):
+        self._rows = rows
+        self.column_names = list(rows[0].keys()) if rows else []
+
+    def __len__(self):
+        return len(self._rows)
+
+    def __getitem__(self, item):
+        if isinstance(item, str):
+            return [r.get(item) for r in self._rows]
+        return self._rows[item]
+
+
+class FakeImageProcessor:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+
+    def __call__(self, image, return_tensors=None, do_resize=True, do_normalize=True, do_augment=False):
+        arr = np.asarray(image, dtype=np.float32)
+        if do_normalize and arr.max() > 1:
+            arr = arr / 255.0
+        if do_augment:
+            arr = arr + 0.1
+        # return HWC to exercise channel-order conversion.
+        return {"pixel_values": arr}
+
+
+def _install_fake_transformers():
+    fake_mod = types.SimpleNamespace(AutoImageProcessor=FakeImageProcessor)
+    sys.modules["transformers"] = fake_mod
+
+
+def test_image_classification_routing_and_deterministic_eval():
+    _install_fake_transformers()
+    train_rows = [
+        {"image": np.zeros((4, 4, 3), dtype=np.uint8), "label": 0},
+        {"image": np.ones((4, 4, 3), dtype=np.uint8) * 255, "label": 1},
+    ]
+    test_rows = [{"image": np.ones((4, 4, 3), dtype=np.uint8), "label": 1}]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "sequence_classification", "modality": "image", "task_type": "classification", "hf_id": "dummy"},
+        hf_model_id="dummy/vision",
+        training_augmentations=True,
+        eval_augmentations=False,
+    )
+
+    x_train, y_train = train
+    x_test, y_test = test
+
+    assert meta["hf_task"] == "image_classification"
+    assert x_train["pixel_values"].shape == (2, 3, 4, 4)
+    assert x_test["pixel_values"].shape == (1, 3, 4, 4)
+    assert float(x_train["pixel_values"][0, 0, 0, 0]) == 0.1
+    assert float(x_test["pixel_values"][0, 0, 0, 0]) != 0.1
+    assert y_train.dtype == np.int64
+    assert y_test.dtype == np.int64
+
+
+def test_image_decode_error_skip_and_report():
+    _install_fake_transformers()
+    train_rows = [
+        {"image": np.zeros((2, 2, 3), dtype=np.uint8), "label": 0},
+        {"image": object(), "label": 1},
+    ]
+    test_rows = [{"image": np.zeros((2, 2, 3), dtype=np.uint8), "label": 0}]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "sequence_classification", "modality": "image", "task_type": "classification", "hf_id": "dummy"},
+        hf_model_id="dummy/vision",
+        on_decode_error="skip",
+        report_decode_errors=True,
+    )
+
+    x_train, y_train = train
+    assert x_train["pixel_values"].shape[0] == 1
+    assert y_train.shape[0] == 1
+    assert meta["decode_report"]["train"]["failed"] == 1
+
+
+def test_image_detection_schema_passthrough():
+    _install_fake_transformers()
+    train_rows = [
+        {"image": np.zeros((2, 2, 3), dtype=np.uint8), "boxes": [[0, 0, 1, 1]], "classes": [2]},
+    ]
+    test_rows = [
+        {"image": np.zeros((2, 2, 3), dtype=np.uint8), "boxes": [], "classes": []},
+    ]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "sequence_classification", "modality": "image", "task_type": "detection", "hf_id": "dummy"},
+        hf_model_id="dummy/vision",
+        boxes_column="boxes",
+        classes_column="classes",
+    )
+
+    _, y_train = train
+    assert meta["schema"]["detection"]["boxes_column"] == "boxes"
+    assert y_train[0]["boxes"].shape == (1, 4)
+    assert y_train[0]["classes"].shape == (1,)

--- a/mlaas_data_generator/test/test_hf_source_image_schema.py
+++ b/mlaas_data_generator/test/test_hf_source_image_schema.py
@@ -1,0 +1,62 @@
+import sys
+import types
+
+import pytest
+
+from mlaas_data_generator.data.sources.huggingface import load_huggingface_source
+
+
+class DummyDS:
+    def __init__(self, rows):
+        self.rows = rows
+        self.column_names = list(rows[0].keys()) if rows else []
+
+    def __len__(self):
+        return len(self.rows)
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            return [r.get(key) for r in self.rows]
+        return self.rows[key]
+
+    def select(self, idxs):
+        return DummyDS([self.rows[i] for i in idxs])
+
+    def train_test_split(self, test_size=0.2, seed=42, shuffle=True):
+        n_test = max(1, int(len(self.rows) * test_size))
+        return {"train": DummyDS(self.rows[:-n_test]), "test": DummyDS(self.rows[-n_test:])}
+
+
+def test_hf_source_image_schema_classification(monkeypatch):
+    ds = DummyDS([
+        {"image": object(), "label": 0, "boxes": [[1, 2, 3, 4]], "classes": [1], "mask": [[1]]},
+        {"image": object(), "label": 1, "boxes": [[1, 2, 3, 4]], "classes": [1], "mask": [[0]]},
+    ])
+
+    fake_mod = types.SimpleNamespace(load_dataset=lambda *args, **kwargs: ds)
+    monkeypatch.setitem(sys.modules, "datasets", fake_mod)
+
+    _, _, meta = load_huggingface_source(
+        dataset_name="dummy",
+        modality="image",
+        task="classification",
+        image_column="image",
+        label_column="label",
+        boxes_column="boxes",
+        classes_column="classes",
+        mask_column="mask",
+    )
+
+    assert meta["schema"]["image_column"] == "image"
+    assert meta["schema"]["label_column"] == "label"
+    assert meta["schema"]["detection"]["boxes_column"] == "boxes"
+    assert meta["schema"]["segmentation"]["mask_column"] == "mask"
+
+
+def test_hf_source_image_requires_label_for_classification(monkeypatch):
+    ds = DummyDS([{"image": object()}])
+    fake_mod = types.SimpleNamespace(load_dataset=lambda *args, **kwargs: ds)
+    monkeypatch.setitem(sys.modules, "datasets", fake_mod)
+
+    with pytest.raises(ValueError):
+        load_huggingface_source(dataset_name="dummy", modality="image", task="classification", image_column="image")


### PR DESCRIPTION
### Motivation
- Extend Hugging Face source/loader flow to support `modality="image"` so image datasets can be routed to image-aware preprocessing and metadata schema extraction.
- Provide robust image decoding, normalization and optional training-time augmentations while keeping eval/inference deterministic.
- Support common image tasks (classification, detection, segmentation) with explicit schema and configurable error handling for corrupt samples.

### Description
- Add image modality validation and schema extraction to the HF source in `mlaas_data_generator/data/sources/huggingface.py`, including checks for `image_column`, `label_column`, `boxes/classes`, and `mask` columns and storing `meta["schema"]`.
- Implement a new HF image preprocessor in `mlaas_data_generator/data/preprocessors/hf_image.py` that uses `transformers.AutoImageProcessor` to decode/normalize images from arrays/bytes/paths, enforce RGB channel/order consistency, apply optional train-time augmentations, and expose `on_decode_error` policies (`skip`/`raise`/`report`) with decode reports.
- Update the HF router in `mlaas_data_generator/data/preprocessors/hf.py` to recognize `modality="image"` and dispatch to `preprocess_hf_image`, and add image-specific expected output keys (`pixel_values`) and validation logic.
- Register a generic HF preprocessor alias in `mlaas_data_generator/data/master_loader.py` so HF dataset loads default to the unified `hf` preprocessor while preserving compatibility with the previous `hf_text` alias.
- Add focused unit tests: `mlaas_data_generator/test/test_hf_image_preprocessor.py` for routing, deterministic eval (augmentations disabled), decode error handling, and detection label normalization, and `mlaas_data_generator/test/test_hf_source_image_schema.py` for source-side schema validation and required label checks.

### Testing
- File syntax checks passed via `python -m py_compile` for the modified source and new test files, which succeeded without runtime imports failing.
- Attempted to run `pytest -q` for the new image tests plus an existing HF generation preprocessor test, but collection failed due to missing runtime dependencies in the environment (`ModuleNotFoundError: No module named 'numpy'`) and package import path setup, so full runtime assertions could not complete here.
- New tests added are `test_hf_image_preprocessor.py` and `test_hf_source_image_schema.py` and they are designed to run with `numpy`, `transformers` (or fakes in tests), and `datasets` available; their assertions validate routing, pixel shape/channel order, augmentation determinism, decode error reporting, and schema passthrough.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7dc144d488330b6bd399c7d7098a7)