### PR TITLE
Add explicit HF loader templates and make HF dispatch driven by `loader_template`

### DIFF
--- a/mlaas_data_generator/data/master_loader.py
+++ b/mlaas_data_generator/data/master_loader.py
@@ -17,6 +17,12 @@ PREPROCESSOR_REGISTRY = {
     "image_float01": preprocess_image_float01,
     "hf": preprocess_hf,
     "hf_text": preprocess_hf,
+    "hf_text_classification": preprocess_hf,
+    "hf_token_classification": preprocess_hf,
+    "hf_sentence_pair_classification": preprocess_hf,
+    "hf_masked_lm": preprocess_hf,
+    "hf_causal_lm": preprocess_hf,
+    "hf_seq2seq": preprocess_hf,
 }
 
 

--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -23,6 +23,62 @@ _EXPECTED_BATCH_KEYS = {
     "multimodal": {"input_ids", "attention_mask", "pixel_values"},
 }
 
+_DATASET_TEMPLATE_TO_TASK = {
+    "hf_text_classification": "sequence_classification",
+    "hf_token_classification": "token_classification",
+    "hf_sentence_pair_classification": "sentence_similarity",
+    "hf_masked_lm": "fill_mask",
+    "hf_causal_lm": "causal_lm_generation",
+    "hf_seq2seq": "seq2seq_generation",
+    # backwards compatibility
+    "hf_text_sequence": "sequence_classification",
+    "hf_text_token": "token_classification",
+    "hf_text_similarity": "sentence_similarity",
+    "hf_text_fill_mask": "fill_mask",
+    "hf_text_generation": None,
+}
+
+
+def _normalize_hf_task(hf_task):
+    task = str(hf_task or "sequence_classification").strip().lower().replace("-", "_")
+    aliases = {
+        "text_classification": "sequence_classification",
+        "seq_cls": "sequence_classification",
+        "token_cls": "token_classification",
+        "masked_lm": "fill_mask",
+        "mlm": "fill_mask",
+        "text_generation": "causal_lm_generation",
+        "causal_lm": "causal_lm_generation",
+        "text2text": "seq2seq_generation",
+        "text2text_generation": "seq2seq_generation",
+        "vision_classification": "image_classification",
+        "image_cls": "image_classification",
+        "object_detection": "image_detection",
+        "detection": "image_detection",
+        "semantic_segmentation": "image_segmentation",
+        "segmentation": "image_segmentation",
+    }
+    return aliases.get(task, task)
+
+
+def _resolve_dataset_loader_template(meta, dataset_args):
+    dataset_meta = meta.get("dataset_args") if isinstance(meta.get("dataset_args"), dict) else {}
+    template = dataset_args.get("loader_template") or meta.get("loader_template") or dataset_meta.get("loader_template")
+    return str(template).strip().lower() if template else None
+
+
+def _resolve_text_hf_task(meta, dataset_args):
+    template = _resolve_dataset_loader_template(meta, dataset_args)
+    if template == "hf_text_generation":
+        task_tag = str(meta.get("task_tag") or dataset_args.get("task_tag") or "").strip().lower().replace("-", "_")
+        pipeline_tag = str(meta.get("pipeline_tag") or dataset_args.get("pipeline_tag") or "").strip().lower()
+        if task_tag in {"summarization", "translation", "seq2seq", "text2text"} or pipeline_tag == "text2text-generation":
+            return "seq2seq_generation"
+        return "causal_lm_generation"
+    mapped = _DATASET_TEMPLATE_TO_TASK.get(template)
+    if mapped:
+        return mapped
+    return _normalize_hf_task(meta.get("hf_task", dataset_args.get("hf_task", "sequence_classification")))
 
 
 def _validate_hf_preprocessor_output(train, test, meta):
@@ -58,10 +114,6 @@ def _validate_hf_preprocessor_output(train, test, meta):
 
 def preprocess_hf(train, test, meta, **dataset_args):
     modality = str(meta.get("modality", "text")).strip().lower()
-    hf_task = str(meta.get("hf_task", "sequence_classification")).strip().lower().replace("-", "_")
-    if hf_task in {"mlm", "masked_lm"}:
-        hf_task = "fill_mask"
-
     hf_model_id = dataset_args.get("hf_model_id")
     if not hf_model_id:
         raise ValueError("HF preprocessing requires hf_model_id in dataset_args")
@@ -88,7 +140,6 @@ def preprocess_hf(train, test, meta, **dataset_args):
         )
         return _validate_hf_preprocessor_output(*out)
 
-
     if modality == "multimodal":
         meta["hf_task"] = "multimodal"
         out = preprocess_hf_multimodal(
@@ -106,6 +157,9 @@ def preprocess_hf(train, test, meta, **dataset_args):
 
     if modality != "text":
         raise NotImplementedError(f"HF modality '{modality}' not implemented")
+
+    hf_task = _resolve_text_hf_task(meta, dataset_args)
+    meta["hf_task"] = hf_task
 
     if hf_task == "sequence_classification":
         out = preprocess_hf_text_sequence(

--- a/mlaas_data_generator/data/sources/huggingface.py
+++ b/mlaas_data_generator/data/sources/huggingface.py
@@ -207,6 +207,7 @@ def load_huggingface_source(**kwargs):
         "modality": modality,
         "hf_task": hf_task,
         "schema": schema,
+        "loader_template": dataset_args.get("loader_template"),
         "dataset_args": dataset_args,
     }
 

--- a/mlaas_data_generator/models/adapters/hf_adapter.py
+++ b/mlaas_data_generator/models/adapters/hf_adapter.py
@@ -16,15 +16,82 @@ from .hf_task import (
 )
 
 
+def _normalize_hf_task_name(hf_task):
+    task = str(hf_task or "sequence_classification").strip().lower().replace("-", "_")
+    aliases = {
+        "text_classification": "sequence_classification",
+        "seq_cls": "sequence_classification",
+        "token_cls": "token_classification",
+        "masked_lm": "fill_mask",
+        "mlm": "fill_mask",
+        "text_generation": "causal_lm_generation",
+        "causal_lm": "causal_lm_generation",
+        "text2text": "seq2seq_generation",
+        "text2text_generation": "seq2seq_generation",
+        "vision_classification": "image_classification",
+        "image_cls": "image_classification",
+        "object_detection": "image_detection",
+        "detection": "image_detection",
+        "semantic_segmentation": "image_segmentation",
+        "segmentation": "image_segmentation",
+    }
+    return aliases.get(task, task)
+
+
+_MODEL_TEMPLATE_TO_TASK = {
+    "hf_sequence_classification": "sequence_classification",
+    "hf_token_classification": "token_classification",
+    "hf_sentence_similarity": "sentence_similarity",
+    "hf_fill_mask": "fill_mask",
+    "hf_causal_lm": "causal_lm_generation",
+    "hf_seq2seq": "seq2seq_generation",
+    # backwards compatibility
+    "auto_sequence_classification": "sequence_classification",
+    "auto_token_classification": "token_classification",
+    "auto_masked_lm": "fill_mask",
+    "auto_causal_lm": "causal_lm_generation",
+    "auto_seq2seq_lm": "seq2seq_generation",
+}
+
+
+def resolve_hf_task(loader_template=None, hf_task=None):
+    template = str(loader_template).strip().lower() if loader_template else None
+    mapped = _MODEL_TEMPLATE_TO_TASK.get(template)
+    if mapped:
+        return mapped
+    return _normalize_hf_task_name(hf_task)
+
+
+def build_task_spec(hf_task=None, *, loader_template=None, num_labels=None, multilabel=False, label_format="single_index"):
+    task = resolve_hf_task(loader_template=loader_template, hf_task=hf_task)
+    if task == "token_classification":
+        return task, TokenClassificationSpec(multilabel=multilabel, label_format=label_format)
+    if task == "sentence_similarity":
+        resolved_num_labels = None if num_labels is None else int(num_labels)
+        is_regression = (str(label_format).lower() == "continuous") or (resolved_num_labels == 1)
+        return task, SentenceSimilaritySpec(is_regression=is_regression)
+    if task == "fill_mask":
+        return task, FillMaskSpec()
+    if task == "causal_lm_generation":
+        return task, CausalLMGenerationSpec()
+    if task == "seq2seq_generation":
+        return task, Seq2SeqGenerationSpec()
+    if task in {"image_classification", "vision_classification"}:
+        return "image_classification", ImageClassificationSpec()
+    if task in {"object_detection", "image_detection", "detection"}:
+        return "image_detection", ObjectDetectionSpec()
+    if task in {"image_segmentation", "semantic_segmentation", "segmentation"}:
+        return "image_segmentation", ImageSegmentationSpec()
+    if task in {"image_captioning", "image_to_text"}:
+        return "image_captioning", ImageCaptioningSpec()
+    if task in {"text_image_retrieval", "image_text_retrieval"}:
+        return "text_image_retrieval", TextImageRetrievalSpec()
+    if task in {"visual_question_answering", "vqa"}:
+        return "visual_question_answering", VQASpec()
+    return "sequence_classification", SequenceClassificationSpec(multilabel=multilabel, label_format=label_format)
+
+
 class TransformersTextFineTuneAdapter:
-    """
-    Wrapper around HFCore.
-
-    Supports loader schema:
-      - x is dict-of-arrays: {"input_ids": ..., "attention_mask": ...}
-      - x can still be legacy raw texts or token lists (kept for backwards compatibility)
-    """
-
     def __init__(
         self,
         model_id,
@@ -33,39 +100,22 @@ class TransformersTextFineTuneAdapter:
         batch_size=16,
         device=None,
         hf_task="sequence_classification",
+        loader_template=None,
         label_pad_value=-100,
         multilabel=False,
         label_format="single_index",
         generation_config=None,
         task_tag=None,
     ):
-        if hf_task == "token_classification":
-            spec = TokenClassificationSpec(multilabel=multilabel, label_format=label_format)
-        elif hf_task == "sentence_similarity":
-            resolved_num_labels = None if num_labels is None else int(num_labels)
-            is_regression = (str(label_format).lower() == "continuous") or (resolved_num_labels == 1)
-            spec = SentenceSimilaritySpec(is_regression=is_regression)
-        elif hf_task == "fill_mask":
-            spec = FillMaskSpec()
-        elif hf_task in {"causal_lm_generation", "causal_lm", "text_generation"}:
-            spec = CausalLMGenerationSpec()
-        elif hf_task in {"seq2seq_generation", "text2text_generation", "text2text"}:
-            spec = Seq2SeqGenerationSpec()
-        elif hf_task in {"image_classification", "vision_classification"}:
-            spec = ImageClassificationSpec()
-        elif hf_task in {"object_detection", "image_detection", "detection"}:
-            spec = ObjectDetectionSpec()
-        elif hf_task in {"image_segmentation", "semantic_segmentation", "segmentation"}:
-            spec = ImageSegmentationSpec()
-        elif hf_task in {"image_captioning", "image_to_text"}:
-            spec = ImageCaptioningSpec()
-        elif hf_task in {"text_image_retrieval", "image_text_retrieval"}:
-            spec = TextImageRetrievalSpec()
-        elif hf_task in {"visual_question_answering", "vqa"}:
-            spec = VQASpec()
-        else:
-            spec = SequenceClassificationSpec(multilabel=multilabel, label_format=label_format)
-
+        resolved_task, spec = build_task_spec(
+            hf_task,
+            loader_template=loader_template,
+            num_labels=num_labels,
+            multilabel=multilabel,
+            label_format=label_format,
+        )
+        self.resolved_hf_task = resolved_task
+        self.loader_template = loader_template
         self.core = HFCore(
             model_id=model_id,
             num_labels=(None if num_labels is None else int(num_labels)),
@@ -77,7 +127,6 @@ class TransformersTextFineTuneAdapter:
             generation_config=generation_config,
             task_tag=task_tag,
         )
-
         self.model_id = model_id
         self.max_length = int(max_length)
         self.batch_size = int(batch_size)
@@ -93,13 +142,7 @@ class TransformersTextFineTuneAdapter:
         self.core.set_weights(weights_dict)
 
     def fit(self, x, y, epochs=1, lr=5e-5, max_train_time_s=60):
-        return self.core.finetune(
-            x,
-            y,
-            epochs=epochs,
-            lr=lr,
-            max_train_time_s=max_train_time_s,
-        )
+        return self.core.finetune(x, y, epochs=epochs, lr=lr, max_train_time_s=max_train_time_s)
 
     def evaluate(self, x, y, inference_only=False):
         loss, primary, secondary, qos = self.core.eval(x, y, inference_only=inference_only)
@@ -107,11 +150,6 @@ class TransformersTextFineTuneAdapter:
 
 
 class TransformersTextClassifierAdapter:
-    """
-    Inference-style adapter (loads an already-finetuned sequence classification model_id).
-    Uses HFCore batching/eval utilities, including dict-of-arrays support.
-    """
-
     def __init__(
         self,
         model_id,
@@ -119,35 +157,11 @@ class TransformersTextClassifierAdapter:
         batch_size=16,
         device=None,
         hf_task="sequence_classification",
+        loader_template=None,
         generation_config=None,
         task_tag=None,
     ):
-        task = str(hf_task or "sequence_classification").lower().replace("-", "_")
-        if task in {"causal_lm_generation", "causal_lm", "text_generation"}:
-            spec = CausalLMGenerationSpec()
-        elif task in {"seq2seq_generation", "text2text_generation", "text2text"}:
-            spec = Seq2SeqGenerationSpec()
-        elif task == "fill_mask":
-            spec = FillMaskSpec()
-        elif task == "token_classification":
-            spec = TokenClassificationSpec()
-        elif task == "sentence_similarity":
-            spec = SentenceSimilaritySpec(is_regression=True)
-        elif task in {"image_classification", "vision_classification"}:
-            spec = ImageClassificationSpec()
-        elif task in {"object_detection", "image_detection", "detection"}:
-            spec = ObjectDetectionSpec()
-        elif task in {"image_segmentation", "semantic_segmentation", "segmentation"}:
-            spec = ImageSegmentationSpec()
-        elif task in {"image_captioning", "image_to_text"}:
-            spec = ImageCaptioningSpec()
-        elif task in {"text_image_retrieval", "image_text_retrieval"}:
-            spec = TextImageRetrievalSpec()
-        elif task in {"visual_question_answering", "vqa"}:
-            spec = VQASpec()
-        else:
-            spec = SequenceClassificationSpec()
-
+        task, spec = build_task_spec(hf_task, loader_template=loader_template, num_labels=None)
         core = HFCore(
             model_id=model_id,
             num_labels=None,
@@ -162,25 +176,25 @@ class TransformersTextClassifierAdapter:
         transformers = core.transformers
         if core.model is None:
             def _load_model():
-                if task in {"causal_lm_generation", "causal_lm", "text_generation"}:
+                if task == "causal_lm_generation":
                     return transformers.AutoModelForCausalLM.from_pretrained(model_id)
-                if task in {"seq2seq_generation", "text2text_generation", "text2text"}:
+                if task == "seq2seq_generation":
                     return transformers.AutoModelForSeq2SeqLM.from_pretrained(model_id)
                 if task == "fill_mask":
                     return transformers.AutoModelForMaskedLM.from_pretrained(model_id)
                 if task == "token_classification":
                     return transformers.AutoModelForTokenClassification.from_pretrained(model_id)
-                if task in {"image_classification", "vision_classification"}:
+                if task == "image_classification":
                     return transformers.AutoModelForImageClassification.from_pretrained(model_id)
-                if task in {"object_detection", "image_detection", "detection"}:
+                if task == "image_detection":
                     return transformers.AutoModelForObjectDetection.from_pretrained(model_id)
-                if task in {"image_segmentation", "semantic_segmentation", "segmentation"}:
+                if task == "image_segmentation":
                     return transformers.AutoModelForSemanticSegmentation.from_pretrained(model_id)
-                if task in {"image_captioning", "image_to_text"}:
+                if task == "image_captioning":
                     return transformers.AutoModelForVision2Seq.from_pretrained(model_id)
-                if task in {"text_image_retrieval", "image_text_retrieval"}:
+                if task == "text_image_retrieval":
                     return transformers.AutoModel.from_pretrained(model_id)
-                if task in {"visual_question_answering", "vqa"}:
+                if task == "visual_question_answering":
                     return transformers.AutoModelForVisualQuestionAnswering.from_pretrained(model_id)
                 return transformers.AutoModelForSequenceClassification.from_pretrained(model_id)
 
@@ -199,6 +213,8 @@ class TransformersTextClassifierAdapter:
         self.max_length = int(max_length)
         self.batch_size = int(batch_size)
         self.device = self.core.device
+        self.resolved_hf_task = task
+        self.loader_template = loader_template
 
     def evaluate(self, x, y, inference_only=True):
         loss, primary, secondary, qos = self.core.eval(x, y, inference_only=inference_only)

--- a/mlaas_data_generator/models/builders.py
+++ b/mlaas_data_generator/models/builders.py
@@ -23,26 +23,7 @@ def _make_optimizer(name: str, lr: float):
         return optimizers.AdamW(learning_rate=lr)
     return optimizers.Adam(learning_rate=lr)
 
-def _normalize_hf_task_name(hf_task):
-    task = str(hf_task or "sequence_classification").strip().lower().replace("-", "_")
-    aliases = {
-        "text_classification": "sequence_classification",
-        "seq_cls": "sequence_classification",
-        "token_cls": "token_classification",
-        "masked_lm": "fill_mask",
-        "mlm": "fill_mask",
-        "text_generation": "causal_lm_generation",
-        "causal_lm": "causal_lm_generation",
-        "text2text": "seq2seq_generation",
-        "text2text_generation": "seq2seq_generation",
-        "vision_classification": "image_classification",
-        "image_cls": "image_classification",
-        "object_detection": "image_detection",
-        "detection": "image_detection",
-        "semantic_segmentation": "image_segmentation",
-        "segmentation": "image_segmentation",
-    }
-    return aliases.get(task, task)
+from .adapters.hf_adapter import resolve_hf_task
 
 def create_model(
     input_shape,
@@ -79,10 +60,12 @@ def create_model(
         if not model_id:
             raise ValueError("HF fine-tune model_type requires hf_model_id=<huggingface_model_repo_id>")
 
+        loader_template = (meta or {}).get("loader_template") if isinstance(meta, dict) else None
+        loader_template = loader_template or kwargs.get("loader_template")
         hf_task = None
         if isinstance(meta, dict):
             hf_task = meta.get("hf_task")
-        hf_task = _normalize_hf_task_name(hf_task or kwargs.get("hf_task", "sequence_classification"))
+        hf_task = resolve_hf_task(loader_template=loader_template, hf_task=hf_task or kwargs.get("hf_task", "sequence_classification"))
 
         label_pad_value = infer_ignore_index(meta if isinstance(meta, dict) else None, default=int(kwargs.get("label_pad_value", -100)))
         
@@ -127,6 +110,7 @@ def create_model(
             batch_size=batch_size,
             device=device,
             hf_task=hf_task,
+            loader_template=loader_template,
             label_pad_value=label_pad_value,
             multilabel=multilabel,
             label_format=label_format,
@@ -144,10 +128,12 @@ def create_model(
         if not model_id:
             raise ValueError("HF model_type requires hf_model_id=<huggingface_model_repo_id>")
 
+        loader_template = (meta or {}).get("loader_template") if isinstance(meta, dict) else None
+        loader_template = loader_template or kwargs.get("loader_template")
         hf_task = None
         if isinstance(meta, dict):
             hf_task = meta.get("hf_task")
-        hf_task = _normalize_hf_task_name(hf_task or kwargs.get("hf_task", "sequence_classification"))
+        hf_task = resolve_hf_task(loader_template=loader_template, hf_task=hf_task or kwargs.get("hf_task", "sequence_classification"))
 
         max_length = kwargs.get("max_length", None)
         if max_length is None and isinstance(meta, dict):
@@ -180,6 +166,7 @@ def create_model(
             batch_size=batch_size,
             device=device,
             hf_task=hf_task,
+            loader_template=loader_template,
             generation_config=generation_config,
             task_tag=kwargs.get("task_tag", (meta or {}).get("task_tag") if isinstance(meta, dict) else None),
         )

--- a/mlaas_data_generator/registry/datasets.py
+++ b/mlaas_data_generator/registry/datasets.py
@@ -11,7 +11,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "sentence",
         "label_column": "label",
         "input_schema": "single_text",
-        "loader_template": "hf_text_sequence",
+        "loader_template": "hf_text_classification",
         "max_samples": 600,
         "max_length": 128,
         "explainability": {
@@ -30,7 +30,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "text",
         "label_column": "label",
         "input_schema": "single_text",
-        "loader_template": "hf_text_sequence",
+        "loader_template": "hf_text_classification",
         "max_samples": 800,
         "max_length": 128,
         "explainability": {
@@ -49,7 +49,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "text",
         "label_column": "label",
         "input_schema": "single_text",
-        "loader_template": "hf_text_sequence",
+        "loader_template": "hf_text_classification",
         "max_samples": 1200,
         "max_length": 256,
         "explainability": {
@@ -68,7 +68,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "tokens",
         "label_column": "ner_tags",
         "input_schema": "token_sequence",
-        "loader_template": "hf_text_token",
+        "loader_template": "hf_token_classification",
         "max_samples": 800,
         "max_length": 128,
         "explainability": {
@@ -87,7 +87,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "tokens",
         "label_column": "ner_tags",
         "input_schema": "token_sequence",
-        "loader_template": "hf_text_token",
+        "loader_template": "hf_token_classification",
         "max_samples": 600,
         "max_length": 128,
         "explainability": {
@@ -106,7 +106,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": ["sentence1", "sentence2"],
         "label_column": "label",
         "input_schema": "text_pair",
-        "loader_template": "hf_text_similarity",
+        "loader_template": "hf_sentence_pair_classification",
         "task_type": "regression",
         "max_samples": 800,
         "max_length": 128,
@@ -126,7 +126,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": ["sentence1", "sentence2"],
         "label_column": "label",
         "input_schema": "text_pair",
-        "loader_template": "hf_text_similarity",
+        "loader_template": "hf_sentence_pair_classification",
         "max_samples": 800,
         "max_length": 128,
         "explainability": {
@@ -145,7 +145,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "text",
         "label_column": "text",
         "input_schema": "single_text",
-        "loader_template": "hf_text_fill_mask",
+        "loader_template": "hf_masked_lm",
         "max_samples": 1200,
         "max_length": 128,
         "explainability": {
@@ -164,7 +164,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "text",
         "label_column": "text",
         "input_schema": "single_text",
-        "loader_template": "hf_text_fill_mask",
+        "loader_template": "hf_masked_lm",
         "max_samples": 1000,
         "max_length": 128,
         "explainability": {
@@ -183,7 +183,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "text",
         "label_column": "text",
         "input_schema": "single_text",
-        "loader_template": "hf_text_generation",
+        "loader_template": "hf_causal_lm",
         "task_tag": "language-modeling",
         "max_samples": 1000,
         "max_length": 256,
@@ -203,7 +203,7 @@ DATASET_REGISTRY: dict[str, dict[str, object]] = {
         "text_column": "article",
         "label_column": "highlights",
         "input_schema": "single_text",
-        "loader_template": "hf_text_generation",
+        "loader_template": "hf_seq2seq",
         "task_tag": "summarization",
         "max_samples": 1000,
         "max_length": 256,

--- a/mlaas_data_generator/registry/models.py
+++ b/mlaas_data_generator/registry/models.py
@@ -10,7 +10,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["glue_sst2", "ag_news", "imdb"],
-        "loader_template": "auto_sequence_classification",
+        "loader_template": "hf_sequence_classification",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -26,7 +26,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["ag_news", "imdb"],
-        "loader_template": "auto_sequence_classification",
+        "loader_template": "hf_sequence_classification",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -42,7 +42,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["glue_sst2", "ag_news"],
-        "loader_template": "auto_sequence_classification",
+        "loader_template": "hf_sequence_classification",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -58,7 +58,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["conll2003", "wnut_17"],
-        "loader_template": "auto_token_classification",
+        "loader_template": "hf_token_classification",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -74,7 +74,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["conll2003"],
-        "loader_template": "auto_token_classification",
+        "loader_template": "hf_token_classification",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -90,7 +90,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["wnut_17"],
-        "loader_template": "auto_token_classification",
+        "loader_template": "hf_token_classification",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -106,7 +106,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["glue_stsb", "glue_mrpc"],
-        "loader_template": "auto_sequence_classification",
+        "loader_template": "hf_sentence_similarity",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -122,7 +122,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["glue_stsb", "glue_mrpc"],
-        "loader_template": "auto_sequence_classification",
+        "loader_template": "hf_sentence_similarity",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -138,7 +138,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["glue_stsb"],
-        "loader_template": "auto_sequence_classification",
+        "loader_template": "hf_sentence_similarity",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": False,
@@ -154,7 +154,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["wikitext2", "ag_news_fillmask"],
-        "loader_template": "auto_masked_lm",
+        "loader_template": "hf_fill_mask",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -170,7 +170,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["wikitext2", "ag_news_fillmask"],
-        "loader_template": "auto_masked_lm",
+        "loader_template": "hf_fill_mask",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -186,7 +186,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["wikitext2_lm"],
-        "loader_template": "auto_causal_lm",
+        "loader_template": "hf_causal_lm",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": False,
@@ -202,7 +202,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["wikitext2_lm"],
-        "loader_template": "auto_causal_lm",
+        "loader_template": "hf_causal_lm",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": False,
@@ -218,7 +218,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["cnn_dailymail"],
-        "loader_template": "auto_seq2seq_lm",
+        "loader_template": "hf_seq2seq",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,
@@ -234,7 +234,7 @@ MODEL_REGISTRY: dict[str, dict[str, object]] = {
         "model_role": "task_head",
         "allowed_run_regimes": ["finetune_transfer", "inference_only"],
         "dataset_keys": ["cnn_dailymail"],
-        "loader_template": "auto_seq2seq_lm",
+        "loader_template": "hf_seq2seq",
         "explainability": {
             "supports_gradients": True,
             "supports_attention_rollout": True,

--- a/mlaas_data_generator/test/test_generation_metrics_and_manifest.py
+++ b/mlaas_data_generator/test/test_generation_metrics_and_manifest.py
@@ -9,7 +9,7 @@ def test_generation_registries_cover_curated_tasks_and_metadata():
     }
     assert set(generation_datasets) == {"wikitext2_lm", "cnn_dailymail"}
     assert generation_datasets["wikitext2_lm"]["pipeline_tag"] == "text-generation"
-    assert generation_datasets["wikitext2_lm"]["loader_template"] == "hf_text_generation"
+    assert generation_datasets["wikitext2_lm"]["loader_template"] == "hf_causal_lm"
     assert generation_datasets["wikitext2_lm"]["explainability"]["supports_feature_attribution"] is True
 
     assert generation_datasets["cnn_dailymail"]["pipeline_tag"] == "text2text-generation"
@@ -26,7 +26,7 @@ def test_generation_registries_cover_curated_tasks_and_metadata():
         "t5-small",
     }
     assert generation_models["distilgpt2_textgen"]["pipeline_tag"] == "text-generation"
-    assert generation_models["distilgpt2_textgen"]["loader_template"] == "auto_causal_lm"
+    assert generation_models["distilgpt2_textgen"]["loader_template"] == "hf_causal_lm"
     assert generation_models["distilgpt2_textgen"]["allowed_run_regimes"] == ["finetune_transfer", "inference_only"]
     assert generation_models["flan-t5-small_text2text"]["pipeline_tag"] == "text2text-generation"
     assert generation_models["flan-t5-small_text2text"]["family"] == "t5"

--- a/mlaas_data_generator/test/test_loader_templates.py
+++ b/mlaas_data_generator/test/test_loader_templates.py
@@ -1,0 +1,60 @@
+from mlaas_data_generator.data.preprocessors import hf as hf_preprocessors
+from mlaas_data_generator.models.adapters.hf_adapter import build_task_spec, resolve_hf_task
+
+
+def test_dataset_loader_templates_dispatch_to_expected_preprocessors(monkeypatch):
+    calls = []
+
+    def _stub(name):
+        def _inner(train, test, meta, **kwargs):
+            calls.append(name)
+            meta = dict(meta)
+            return ({"input_ids": [[1]], "attention_mask": [[1]]}, [0]), ({"input_ids": [[1]], "attention_mask": [[1]]}, [0]), meta
+        return _inner
+
+    monkeypatch.setattr(hf_preprocessors, "preprocess_hf_text_sequence", _stub("sequence"))
+    monkeypatch.setattr(hf_preprocessors, "preprocess_hf_text_token", _stub("token"))
+    monkeypatch.setattr(hf_preprocessors, "preprocess_hf_text_similarity", _stub("similarity"))
+    monkeypatch.setattr(hf_preprocessors, "preprocess_hf_text_fill_mask", _stub("fill_mask"))
+    monkeypatch.setattr(hf_preprocessors, "preprocess_hf_text_causal_lm_generation", _stub("causal_lm"))
+    monkeypatch.setattr(hf_preprocessors, "preprocess_hf_text_seq2seq_generation", _stub("seq2seq"))
+
+    base_meta = {"modality": "text", "hf_id": "dummy"}
+    base_train = (["x"], None)
+    base_test = (["y"], None)
+
+    template_to_expected = {
+        "hf_text_classification": ("sequence", "sequence_classification"),
+        "hf_token_classification": ("token", "token_classification"),
+        "hf_sentence_pair_classification": ("similarity", "sentence_similarity"),
+        "hf_masked_lm": ("fill_mask", "fill_mask"),
+        "hf_causal_lm": ("causal_lm", "causal_lm_generation"),
+        "hf_seq2seq": ("seq2seq", "seq2seq_generation"),
+    }
+
+    for template, (expected_call, expected_task) in template_to_expected.items():
+        calls.clear()
+        _, _, meta = hf_preprocessors.preprocess_hf(
+            base_train,
+            base_test,
+            dict(base_meta, loader_template=template),
+            hf_model_id="dummy/model",
+            loader_template=template,
+            text_column="text",
+            label_column="label",
+        )
+        assert calls == [expected_call]
+        assert meta["hf_task"] == expected_task
+
+
+def test_model_loader_templates_override_legacy_hf_task():
+    assert resolve_hf_task(loader_template="hf_fill_mask", hf_task="sequence_classification") == "fill_mask"
+    assert resolve_hf_task(loader_template="hf_seq2seq", hf_task="fill_mask") == "seq2seq_generation"
+
+    task, spec = build_task_spec("sequence_classification", loader_template="hf_token_classification", num_labels=3)
+    assert task == "token_classification"
+    assert spec.name == "token_classification"
+
+    task, spec = build_task_spec("fill_mask", loader_template="hf_sentence_similarity", num_labels=1, label_format="continuous")
+    assert task == "sentence_similarity"
+    assert spec.name == "sentence_similarity"


### PR DESCRIPTION
### Motivation
- Make dataset and model loader selection explicit by declaring `loader_template` values in the curated registries so runtime dispatch is predictable and driven by the registry contract. 
- Stop inferring HF behavior from miscellaneous manifest/task columns and instead let `loader_template` determine which preprocessor or model adapter is used. 
- Preserve the existing task-specific preprocessors (sequence/token/similarity/etc.) as implementation targets while changing the public dispatch contract to templates.

### Description
- Introduce explicit dataset loader templates in `DATASET_REGISTRY` such as `hf_text_classification`, `hf_token_classification`, `hf_sentence_pair_classification`, `hf_masked_lm`, `hf_causal_lm`, and `hf_seq2seq`. (`mlaas_data_generator/registry/datasets.py`).
- Introduce explicit model loader templates in `MODEL_REGISTRY` such as `hf_sequence_classification`, `hf_token_classification`, `hf_sentence_similarity`, `hf_fill_mask`, `hf_causal_lm`, and `hf_seq2seq` and map existing model entries to them (`mlaas_data_generator/registry/models.py`).
- Update HF source metadata to propagate `loader_template` from the source through to preprocessing (`mlaas_data_generator/data/sources/huggingface.py`).
- Refactor HF dataset preprocessor dispatch to resolve text tasks from dataset `loader_template` first (with backward-compatible aliases), and then call the existing task-specific preprocessors (`mlaas_data_generator/data/preprocessors/hf.py`).
- Extend the master loader preprocessor registry to include the new explicit HF template names so they can be selected directly (`mlaas_data_generator/data/master_loader.py`).
- Add `resolve_hf_task` / `build_task_spec` logic in the HF model adapter to prefer `loader_template` when choosing an HF `TaskSpec`, and thread `loader_template` through the model builder/adapter path (`mlaas_data_generator/models/adapters/hf_adapter.py`, `mlaas_data_generator/models/builders.py`).
- Add a focused unit test `test_loader_templates.py` that verifies dataset template -> preprocessor dispatch and model template -> task resolution, and update the generation manifest test expectations to match new template names (`mlaas_data_generator/test/test_loader_templates.py`, `mlaas_data_generator/test/test_generation_metrics_and_manifest.py`).

### Testing
- Compiled modified modules with `python -m py_compile` across updated files, which succeeded for the edited modules. 
- Ran small sanity scripts to assert registry `loader_template` values and to exercise `_resolve_text_hf_task` / `resolve_hf_task` mappings, which showed the expected template sets and mappings. 
- Added `mlaas_data_generator/test/test_loader_templates.py` and updated `test_generation_metrics_and_manifest.py` to reflect the new templates; these new/updated tests were compiled as part of the smoke checks. 
- Attempted to run `pytest -q` against the test subset that covers loader/template behavior, but test collection was blocked in this environment due to missing test runtime dependencies (`numpy`) and PYTHONPATH configuration, so full pytest runs could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be1fc186288330b0c098282ea0b222)