### PR TITLE
Add HF evaluation batch diagnostics and progress logging

### DIFF
--- a/mlaas_data_generator/federated/task.py
+++ b/mlaas_data_generator/federated/task.py
@@ -225,6 +225,18 @@ class HFInferenceClassificationStrategy(TaskStrategy):
             if adapter is None:
                 adapter = self.build_model()
 
+            batch_debug = adapter.core.debug_first_processed_batch(x, y, inference_only=False)
+            print(
+                "[evaluate_client] first processed batch | "
+                f"input_ids_shape={batch_debug.get('input_ids_shape')} | "
+                f"attention_mask_shape={batch_debug.get('attention_mask_shape')} | "
+                f"labels_shape={batch_debug.get('labels_shape')} | "
+                f"finite_ok={batch_debug.get('finite_ok')} | "
+                f"nested_object_keys={batch_debug.get('nested_object_keys')}"
+            )
+            print(f"[evaluate_client] token example: {batch_debug.get('token_example')}")
+            print(f"[evaluate_client] ner_tags example: {batch_debug.get('ner_tags_example')}")
+
             loss, acc, f1, qos = adapter.evaluate(x, y)
 
             duration = time.time() - start

--- a/mlaas_data_generator/models/adapters/hf_core.py
+++ b/mlaas_data_generator/models/adapters/hf_core.py
@@ -137,6 +137,90 @@ class HFCore:
             yb = None if ys is None else ys[i:i + bs]
             yield xb, yb
 
+    def _debug_shape(self, value):
+        if value is None:
+            return None
+        shape = getattr(value, "shape", None)
+        if shape is not None:
+            try:
+                return tuple(int(dim) for dim in shape)
+            except Exception:
+                return shape
+        try:
+            arr = np.asarray(value, dtype=object)
+            return tuple(int(dim) for dim in arr.shape)
+        except Exception:
+            return None
+
+    def _debug_preview(self, value, max_items=12):
+        if value is None:
+            return None
+
+        if hasattr(value, "detach"):
+            value = value.detach().cpu().tolist()
+        elif hasattr(value, "tolist"):
+            value = value.tolist()
+
+        sample = value
+        while isinstance(sample, (list, tuple)) and sample:
+            sample = sample[0]
+
+        if isinstance(sample, (list, tuple)):
+            return list(sample[:max_items])
+        return sample
+
+    def debug_first_processed_batch(self, xs, ys, inference_only=False):
+        torch = self.torch
+        batch_iter = self._batch_iter(xs, ys)
+        xb, yb = next(batch_iter)
+        enc, labels_t, _ = self.task_spec.encode_batch(
+            self.tokenizer,
+            xb,
+            yb,
+            self.max_length,
+            torch,
+            self.device,
+            ignore_index=self.label_pad_value,
+            inference_only=bool(inference_only),
+        )
+
+        input_ids = enc.get("input_ids") if isinstance(enc, dict) else None
+        attention_mask = enc.get("attention_mask") if isinstance(enc, dict) else None
+
+        finite_ok = True
+        finite_details = {}
+        if isinstance(enc, dict):
+            for key, tensor in enc.items():
+                if hasattr(tensor, "dtype") and hasattr(torch, "is_floating_point") and torch.is_floating_point(tensor):
+                    finite_value = bool(torch.isfinite(tensor).all().detach().cpu().item())
+                    finite_details[key] = finite_value
+                    finite_ok = finite_ok and finite_value
+        if labels_t is not None and hasattr(labels_t, "dtype") and torch.is_floating_point(labels_t):
+            labels_finite = bool(torch.isfinite(labels_t).all().detach().cpu().item())
+            finite_details["labels"] = labels_finite
+            finite_ok = finite_ok and labels_finite
+
+        nested_object_keys = []
+        if isinstance(xb, dict):
+            for key, value in xb.items():
+                arr = np.asarray(value, dtype=object)
+                if arr.dtype == object:
+                    nested_object_keys.append(str(key))
+
+        token_source = xb.get("tokens") if isinstance(xb, dict) and "tokens" in xb else input_ids
+        tag_source = xb.get("ner_tags") if isinstance(xb, dict) and "ner_tags" in xb else (yb if yb is not None else labels_t)
+
+        return {
+            "input_ids_shape": self._debug_shape(input_ids),
+            "attention_mask_shape": self._debug_shape(attention_mask),
+            "labels_shape": self._debug_shape(labels_t),
+            "token_example": self._debug_preview(token_source),
+            "ner_tags_example": self._debug_preview(tag_source),
+            "finite_ok": bool(finite_ok),
+            "finite_details": finite_details,
+            "nested_object_keys": nested_object_keys,
+        }
+
     def count_params(self):
         if self.model is None:
             return 0
@@ -296,9 +380,13 @@ class HFCore:
         t_start = time.time()
 
         last_extra = {}
+        print(f"[HFCore.eval] dataloader creation starts | inference_only={bool(inference_only)} | batch_size={self.batch_size}")
+        first_batch_logged = False
 
         with torch.no_grad():
             for xb, yb in self._batch_iter(xs, y_true):
+                if not first_batch_logged:
+                    print("[HFCore.eval] first batch pulled")
                 t0 = time.time()
                 labels_recorded = False
 
@@ -316,6 +404,8 @@ class HFCore:
                 last_extra = dict(extra or {})
 
                 if bool(inference_only) and bool(getattr(self.task_spec, "supports_generation", False)):
+                    if not first_batch_logged:
+                        print("[HFCore.eval] model forward starts")
                     pred_t = self.task_spec.generate_predictions(
                         self.model,
                         enc,
@@ -323,12 +413,18 @@ class HFCore:
                         torch,
                         self.generation_config,
                     )
+                    if not first_batch_logged:
+                        print("[HFCore.eval] first batch forward ends")
                     preds_all.append(pred_t.detach().cpu().numpy())
                 else:
                     model_inputs = self.task_spec.build_forward_inputs(enc, labels_t=labels_t, inference_only=bool(inference_only))
+                    if not first_batch_logged:
+                        print("[HFCore.eval] model forward starts")
                     outputs = self.model(**model_inputs)
                     logits = outputs.logits
                     pred_t = self.task_spec.preds_from_logits(torch, logits, extra)
+                    if not first_batch_logged:
+                        print("[HFCore.eval] first batch forward ends")
                     preds_all.append(pred_t.detach().cpu().numpy())
 
                     stat = self.task_spec.batch_metric_statistics(torch, logits, labels_t, extra)
@@ -361,6 +457,7 @@ class HFCore:
                     labels_all.append(labels_t.detach().cpu().numpy())
 
                 latencies_ms.append((time.time() - t0) * 1000.0)
+                first_batch_logged = True
 
         duration_s = time.time() - t_start
 
@@ -372,6 +469,7 @@ class HFCore:
 
         m_stats = self.task_spec.metrics_from_statistics(stats_accum) if stats_accum else None
         if isinstance(m_stats, dict) and m_stats:
+            print("[HFCore.eval] metric computation starts")
             primary = float(m_stats.get("primary", np.nan))
             secondary = float(m_stats.get("secondary", np.nan))
             named_metrics = m_stats.get("named_metrics") if isinstance(m_stats, dict) else None
@@ -379,6 +477,7 @@ class HFCore:
             primary = np.nan
             secondary = np.nan
         else:
+            print("[HFCore.eval] metric computation starts")
             metrics_extra = dict(last_extra or {})
             metrics_extra["task_tag"] = self.task_tag
             metrics_extra["loss_mean"] = loss_mean


### PR DESCRIPTION
### Motivation

- Make it easier to debug evaluation hangs by printing a processed batch and logging evaluation-stage progress so engineers can pinpoint whether issues occur in preprocessing, dataloader iteration, model forward, or metric aggregation.  

### Description

- Add `HFCore.debug_first_processed_batch(...)` plus helpers `_debug_shape` and `_debug_preview` to inspect the first encoded batch (shapes, finiteness, token/NER preview, and detection of object-typed nested fields) in `mlaas_data_generator/models/adapters/hf_core.py`.  
- Add progress logging to `HFCore.eval(...)` to print when dataloader creation starts, when the first batch is pulled, when model forward starts/ends for the first batch, and when metric computation starts.  
- Call the new debug helper right before HF client evaluation in the HF inference path by printing the first processed batch (input ids shape, attention mask shape, labels shape, token example, ner_tags example, and nested-object detection) in `mlaas_data_generator/federated/task.py`.  

### Testing

- Compiled the modified modules with `python -m compileall mlaas_data_generator/models/adapters/hf_core.py mlaas_data_generator/federated/task.py`, which succeeded.  
- Ran targeted tests with `python -m pytest mlaas_data_generator/test/test_loader_templates.py mlaas_data_generator/test/test_cases.py -q`, which failed during test collection due to the environment missing `numpy` (test failure is environmental, not caused by the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be4350dbcc8330b275e786b0d03c70)