### PR TITLE
Add HF evaluation progress diagnostics and optional timeout

### DIFF
--- a/mlaas_data_generator/federated/strategies/hf_strategy.py
+++ b/mlaas_data_generator/federated/strategies/hf_strategy.py
@@ -198,7 +198,16 @@ class HFStrategy(TaskStrategy):
         try:
             if self.inference_only:
                 adapter = global_model if global_model is not None else self.build_model()
-                loss, primary, secondary, qos = adapter.evaluate(x, y, inference_only=True)
+                loss, primary, secondary, qos = adapter.evaluate(
+                    x,
+                    y,
+                    inference_only=True,
+                    max_eval_time_s=self.knobs.get("max_eval_time_s", self.config.get("max_eval_time_s")),
+                    progress_log_interval=self.knobs.get(
+                        "eval_progress_log_interval",
+                        self.config.get("eval_progress_log_interval", 10),
+                    ),
+                )
 
                 duration = time.time() - start
                 usage = tracker.stop(duration)

--- a/mlaas_data_generator/models/adapters/hf_adapter.py
+++ b/mlaas_data_generator/models/adapters/hf_adapter.py
@@ -144,8 +144,14 @@ class TransformersTextFineTuneAdapter:
     def fit(self, x, y, epochs=1, lr=5e-5, max_train_time_s=60):
         return self.core.finetune(x, y, epochs=epochs, lr=lr, max_train_time_s=max_train_time_s)
 
-    def evaluate(self, x, y, inference_only=False):
-        loss, primary, secondary, qos = self.core.eval(x, y, inference_only=inference_only)
+    def evaluate(self, x, y, inference_only=False, max_eval_time_s=None, progress_log_interval=None):
+        loss, primary, secondary, qos = self.core.eval(
+            x,
+            y,
+            inference_only=inference_only,
+            max_eval_time_s=max_eval_time_s,
+            progress_log_interval=progress_log_interval,
+        )
         return loss, primary, secondary, qos
 
 
@@ -216,8 +222,14 @@ class TransformersTextClassifierAdapter:
         self.resolved_hf_task = task
         self.loader_template = loader_template
 
-    def evaluate(self, x, y, inference_only=True):
-        loss, primary, secondary, qos = self.core.eval(x, y, inference_only=inference_only)
+    def evaluate(self, x, y, inference_only=True, max_eval_time_s=None, progress_log_interval=None):
+        loss, primary, secondary, qos = self.core.eval(
+            x,
+            y,
+            inference_only=inference_only,
+            max_eval_time_s=max_eval_time_s,
+            progress_log_interval=progress_log_interval,
+        )
 
         qos = dict(qos)
         if "eval_latency_ms_mean" in qos:

--- a/mlaas_data_generator/models/adapters/hf_core.py
+++ b/mlaas_data_generator/models/adapters/hf_core.py
@@ -352,7 +352,7 @@ class HFCore:
             "train_stopped_early": bool(timeout_hit),
         }
 
-    def eval(self, xs, ys, inference_only=False):
+    def eval(self, xs, ys, inference_only=False, max_eval_time_s=None, progress_log_interval=None):
         torch = self.torch
 
         def _count_supervised_tokens(labels_t, ignore_index):
@@ -380,13 +380,25 @@ class HFCore:
         t_start = time.time()
 
         last_extra = {}
-        print(f"[HFCore.eval] dataloader creation starts | inference_only={bool(inference_only)} | batch_size={self.batch_size}")
+        total_batches = int((n_eval + max(1, self.batch_size) - 1) / max(1, self.batch_size))
+        progress_log_interval = int(progress_log_interval) if progress_log_interval is not None else 0
+        max_eval_time_s = float(max_eval_time_s) if max_eval_time_s is not None else None
+
+        print(
+            f"[HFCore.eval] dataloader creation starts | inference_only={bool(inference_only)} "
+            f"| batch_size={self.batch_size} | eval_samples={n_eval} | total_batches={total_batches}"
+        )
         first_batch_logged = False
 
         with torch.no_grad():
-            for xb, yb in self._batch_iter(xs, y_true):
+            for batch_idx, (xb, yb) in enumerate(self._batch_iter(xs, y_true), start=1):
                 if not first_batch_logged:
                     print("[HFCore.eval] first batch pulled")
+                if max_eval_time_s is not None and (time.time() - t_start) > max_eval_time_s:
+                    raise TimeoutError(
+                        f"HF evaluation exceeded max_eval_time_s={max_eval_time_s} "
+                        f"after batch {batch_idx - 1}/{total_batches}"
+                    )
                 t0 = time.time()
                 labels_recorded = False
 
@@ -457,6 +469,11 @@ class HFCore:
                     labels_all.append(labels_t.detach().cpu().numpy())
 
                 latencies_ms.append((time.time() - t0) * 1000.0)
+                if progress_log_interval > 0 and (batch_idx % progress_log_interval == 0 or batch_idx == total_batches):
+                    print(
+                        f"[HFCore.eval] progress | batch={batch_idx}/{total_batches} "
+                        f"| elapsed_s={time.time() - t_start:.2f}"
+                    )
                 first_batch_logged = True
 
         duration_s = time.time() - t_start


### PR DESCRIPTION
### Motivation
- Long HF evaluation loops produced only a first-batch log then went silent, making runs appear hung when later batches are slow or problematic.
- Provide lightweight visibility and a configurable hard cutoff so evaluation either reports progress or fails fast instead of silently stalling.

### Description
- Add `max_eval_time_s` and `progress_log_interval` parameters to `HFCore.eval` and compute `total_batches`, print an initial summary and periodic progress logs, and raise `TimeoutError` when `max_eval_time_s` is exceeded (file: `mlaas_data_generator/models/adapters/hf_core.py`).
- Thread the new options through HF adapters by updating `TransformersTextFineTuneAdapter.evaluate` and `TransformersTextClassifierAdapter.evaluate` to accept and forward `max_eval_time_s` and `progress_log_interval` (file: `mlaas_data_generator/models/adapters/hf_adapter.py`).
- Wire federated HF inference to pass configurable `max_eval_time_s` and `eval_progress_log_interval` from `knobs`/`config` when running inference-only clients, defaulting progress logs to every 10 batches (file: `mlaas_data_generator/federated/strategies/hf_strategy.py`).

### Testing
- Ran Python syntax/bytecode check with `python -m py_compile mlaas_data_generator/models/adapters/hf_core.py mlaas_data_generator/models/adapters/hf_adapter.py mlaas_data_generator/federated/strategies/hf_strategy.py`, which succeeded.
- Attempted `PYTHONPATH=. pytest -q mlaas_data_generator/test/test_loader_templates.py mlaas_data_generator/test/test_hf_text_dynamic_padding.py`, but test collection failed in this environment due to missing runtime dependency `numpy` so tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be46ad51e0833098cb733da6c29754)