### PR TITLE
Improve seq2seq generation column auto-mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,11 @@ At minimum include:
 - `text_column` (source/prompt text)
 - `label_column` (target text; required for supervised train/perplexity)
 
+For HF generation preprocessing, explicit `dataset_args.column_mapping` always takes priority.
+Without it, `seq2seq_generation` auto-detects the first matching source/target columns in
+a fixed order, including common summarization and translation pairs such as
+`article` → `highlights`, `document` → `summary`, `question` → `answer`, and `src` → `tgt`.
+
 
 ### Multimodal manifest schema (paired image + text)
 

--- a/mlaas_data_generator/data/preprocessors/hf_text_generation.py
+++ b/mlaas_data_generator/data/preprocessors/hf_text_generation.py
@@ -1,6 +1,39 @@
 import numpy as np
 
 
+# Seq2seq auto-mapping priority is ordered from the most explicit generic schema
+# names to common summarization/translation aliases. The first match wins so the
+# behavior stays deterministic whenever multiple plausible columns are present.
+SEQ2SEQ_SOURCE_CANDIDATES = [
+    "source_text",
+    "input",
+    "prompt",
+    "instruction",
+    "text",
+    "source",
+    "article",
+    "document",
+    "context",
+    "question",
+    "src",
+    "input_text",
+]
+
+SEQ2SEQ_TARGET_CANDIDATES = [
+    "target_text",
+    "label",
+    "output",
+    "completion",
+    "response",
+    "target",
+    "highlights",
+    "summary",
+    "answer",
+    "tgt",
+    "output_text",
+]
+
+
 def _first_existing(columns, candidates):
     for name in candidates:
         if name in columns:
@@ -13,12 +46,8 @@ def resolve_generation_columns(ds_train, *, column_mapping=None, hf_task="causal
     mapping = dict(column_mapping or {})
 
     if hf_task == "seq2seq_generation":
-        source_col = mapping.get("source") or _first_existing(cols, [
-            "source_text", "input", "prompt", "instruction", "text", "source",
-        ])
-        target_col = mapping.get("target") or _first_existing(cols, [
-            "target_text", "label", "output", "completion", "response", "target",
-        ])
+        source_col = mapping.get("source") or _first_existing(cols, SEQ2SEQ_SOURCE_CANDIDATES)
+        target_col = mapping.get("target") or _first_existing(cols, SEQ2SEQ_TARGET_CANDIDATES)
         mode = "source_target"
     else:
         prompt_col = mapping.get("prompt") or _first_existing(cols, [

--- a/mlaas_data_generator/test/test_hf_generation_preprocessors.py
+++ b/mlaas_data_generator/test/test_hf_generation_preprocessors.py
@@ -2,6 +2,7 @@ import sys
 import types
 
 import numpy as np
+import pytest
 
 from mlaas_data_generator.data.preprocessors.hf import preprocess_hf
 
@@ -81,7 +82,7 @@ def test_seq2seq_generation_preprocessor_source_target_mapping():
     _install_fake_transformers()
     train_rows = [
         {"source_text": "summarize this long article", "target_text": "short summary"},
-        {"source_text": "another source", "target_text": "target output"},
+        {"source_text": "another source", "target_text": "target output with extra words"},
     ]
     test_rows = [{"source_text": "src", "target_text": "tgt"}]
 
@@ -139,3 +140,67 @@ def test_causal_lm_generation_preprocessor_single_text_column():
     assert np.array_equal(y_test[non_pad_test], x_test["input_ids"][non_pad_test])
     assert np.all(y_train[~non_pad_train] == -100)
     assert np.all(y_test[~non_pad_test] == -100)
+
+
+def test_seq2seq_generation_preprocessor_article_highlights_mapping():
+    _install_fake_transformers()
+    train_rows = [
+        {"article": "Long article body", "highlights": "Short summary"},
+        {"article": "Another document", "highlights": "Another summary"},
+    ]
+    test_rows = [{"article": "Held-out article", "highlights": "Held-out summary"}]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "seq2seq_generation", "modality": "text", "max_length": 10, "hf_id": "dummy"},
+        hf_model_id="dummy/model",
+        source_max_length=7,
+        target_max_length=5,
+        dynamic_padding=True,
+    )
+
+    x_train, y_train = train
+    x_test, y_test = test
+
+    assert x_train["input_ids"].shape[0] == y_train.shape[0]
+    assert x_test["input_ids"].shape[0] == y_test.shape[0]
+    assert meta["column_mapping"] == {"source": "article", "target": "highlights"}
+
+
+def test_seq2seq_generation_preprocessor_column_mapping_overrides_heuristics():
+    _install_fake_transformers()
+    train_rows = [
+        {"article": "Heuristic source", "highlights": "Heuristic target", "src": "Mapped source", "tgt": "Mapped target"},
+    ]
+    test_rows = [
+        {"article": "Heuristic source test", "highlights": "Heuristic target test", "src": "Mapped source test", "tgt": "Mapped target test"},
+    ]
+
+    _, _, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "seq2seq_generation", "modality": "text", "max_length": 10, "hf_id": "dummy"},
+        hf_model_id="dummy/model",
+        column_mapping={"source": "src", "target": "tgt"},
+        source_max_length=7,
+        target_max_length=5,
+        dynamic_padding=True,
+    )
+
+    assert meta["column_mapping"] == {"source": "src", "target": "tgt"}
+
+
+def test_seq2seq_generation_preprocessor_raises_without_plausible_target():
+    _install_fake_transformers()
+    train_rows = [{"article": "Long article body", "document": "Duplicate candidate source"}]
+    test_rows = [{"article": "Held-out article", "document": "Held-out duplicate source"}]
+
+    with pytest.raises(ValueError, match="Could not resolve target column"):
+        preprocess_hf(
+            (DummySplit(train_rows), None),
+            (DummySplit(test_rows), None),
+            {"hf_task": "seq2seq_generation", "modality": "text", "max_length": 10, "hf_id": "dummy"},
+            hf_model_id="dummy/model",
+            dynamic_padding=True,
+        )


### PR DESCRIPTION
### Motivation
- Make `seq2seq_generation` more robust at auto-detecting source/target columns for common summarization and translation datasets without requiring explicit `dataset_args.column_mapping`.
- Preserve explicit `column_mapping` as highest priority and ensure deterministic, documented heuristics when multiple plausible columns exist.

### Description
- Add ordered candidate lists `SEQ2SEQ_SOURCE_CANDIDATES` and `SEQ2SEQ_TARGET_CANDIDATES` including aliases such as `article`, `document`, `context`, `question`, `src`, `input_text` for sources and `highlights`, `summary`, `answer`, `tgt`, `output_text` for targets, and use them in `resolve_generation_columns` for `hf_task == "seq2seq_generation"`.
- Keep explicit `column_mapping` precedence by checking `mapping.get("source")` / `mapping.get("target")` before heuristics, and document the first-match deterministic behavior in code comments.
- Add targeted tests in `mlaas_data_generator/test/test_hf_generation_preprocessors.py` that cover `article`+`highlights` auto-mapping, explicit `column_mapping` overriding heuristics, and the error path when no plausible target exists.
- Update README (`README.md`) HF generation docs to explain the auto-mapping behavior and that `dataset_args.column_mapping` always takes priority.

### Testing
- Installed test dependencies with `python -m pip install numpy pytest` to resolve environment collection errors.
- Ran tests with `PYTHONPATH=. pytest -q mlaas_data_generator/test/test_hf_generation_preprocessors.py` and observed all targeted tests in that file succeeded (`6 passed`).
- Addressed initial test collection failures (missing `numpy` and missing `PYTHONPATH`) during the run and verified the final test result was green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf7e0384148330b0e55696d6c91653)