### PR TITLE
Refactor HF image task dispatch to use normalized hf_task and canonicalize image_detection

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -10,6 +10,14 @@ from .hf_image import preprocess_hf_image
 from .hf_multimodal import preprocess_hf_multimodal
 
 
+IMAGE_TASK_TYPES = {
+    "image_classification": "classification",
+    "image_detection": "detection",
+    "image_segmentation": "segmentation",
+}
+_IMAGE_TASKS = frozenset(IMAGE_TASK_TYPES)
+
+
 _EXPECTED_BATCH_KEYS = {
     "sequence_classification": {"input_ids", "attention_mask"},
     "token_classification": {"input_ids", "attention_mask"},
@@ -67,6 +75,10 @@ def _resolve_dataset_loader_template(meta, dataset_args):
     return str(template).strip().lower() if template else None
 
 
+def _resolve_image_hf_task(meta, dataset_args):
+    return _normalize_hf_task(meta.get("hf_task", dataset_args.get("hf_task", meta.get("task_type"))))
+
+
 def _resolve_text_hf_task(meta, dataset_args):
     template = _resolve_dataset_loader_template(meta, dataset_args)
     if template == "hf_text_generation":
@@ -114,14 +126,23 @@ def _validate_hf_preprocessor_output(train, test, meta):
 
 def preprocess_hf(train, test, meta, **dataset_args):
     modality = str(meta.get("modality", "text")).strip().lower()
+    hf_task = _resolve_image_hf_task(meta, dataset_args)
     hf_model_id = dataset_args.get("hf_model_id")
     if not hf_model_id:
         raise ValueError("HF preprocessing requires hf_model_id in dataset_args")
 
-    if modality == "image":
-        task_type = str(meta.get("task_type", "classification")).strip().lower()
-        hf_task = f"image_{task_type}"
+    if hf_task in _IMAGE_TASKS or modality == "image":
+        if hf_task in _IMAGE_TASKS:
+            task_type = IMAGE_TASK_TYPES[hf_task]
+        else:
+            task_type = str(meta.get("task_type", "classification")).strip().lower()
+            hf_task = _normalize_hf_task(f"image_{task_type}")
+            if hf_task not in _IMAGE_TASKS:
+                raise ValueError(f"Unsupported HF image task: {hf_task}")
+            task_type = IMAGE_TASK_TYPES[hf_task]
         meta["hf_task"] = hf_task
+        meta["modality"] = "image"
+        meta["task_type"] = task_type
         out = preprocess_hf_image(
             train,
             test,
@@ -160,6 +181,7 @@ def preprocess_hf(train, test, meta, **dataset_args):
 
     hf_task = _resolve_text_hf_task(meta, dataset_args)
     meta["hf_task"] = hf_task
+    meta["modality"] = "text"
 
     if hf_task == "sequence_classification":
         out = preprocess_hf_text_sequence(

--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -433,7 +433,7 @@ class ImageClassificationSpec(HFTaskSpec):
 
 
 class ObjectDetectionSpec(HFTaskSpec):
-    name = "object_detection"
+    name = "image_detection"
 
     def __init__(self, score_threshold=0.05):
         self.score_threshold = float(score_threshold)

--- a/mlaas_data_generator/test/test_hf_image_preprocessor.py
+++ b/mlaas_data_generator/test/test_hf_image_preprocessor.py
@@ -63,8 +63,8 @@ def test_image_classification_routing_and_deterministic_eval():
     assert meta["hf_task"] == "image_classification"
     assert x_train["pixel_values"].shape == (2, 3, 4, 4)
     assert x_test["pixel_values"].shape == (1, 3, 4, 4)
-    assert float(x_train["pixel_values"][0, 0, 0, 0]) == 0.1
-    assert float(x_test["pixel_values"][0, 0, 0, 0]) != 0.1
+    assert np.isclose(float(x_train["pixel_values"][0, 0, 0, 0]), 0.1)
+    assert not np.isclose(float(x_test["pixel_values"][0, 0, 0, 0]), 0.1)
     assert y_train.dtype == np.int64
     assert y_test.dtype == np.int64
 
@@ -114,3 +114,49 @@ def test_image_detection_schema_passthrough():
     assert meta["schema"]["detection"]["boxes_column"] == "boxes"
     assert y_train[0]["boxes"].shape == (1, 4)
     assert y_train[0]["classes"].shape == (1,)
+
+
+def test_image_task_dispatch_uses_hf_task_when_modality_missing():
+    _install_fake_transformers()
+    train_rows = [{"image": np.zeros((3, 3, 3), dtype=np.uint8), "label": 1}]
+    test_rows = [{"image": np.ones((3, 3, 3), dtype=np.uint8), "label": 0}]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "image_classification", "hf_id": "dummy"},
+        hf_model_id="dummy/vision",
+    )
+
+    x_train, y_train = train
+    x_test, y_test = test
+    assert meta["modality"] == "image"
+    assert meta["task_type"] == "classification"
+    assert meta["hf_task"] == "image_classification"
+    assert x_train["pixel_values"].shape == (1, 3, 3, 3)
+    assert x_test["pixel_values"].shape == (1, 3, 3, 3)
+    assert y_train.tolist() == [1]
+    assert y_test.tolist() == [0]
+
+
+def test_image_task_dispatch_normalizes_detection_alias_with_wrong_modality():
+    _install_fake_transformers()
+    train_rows = [{"image": np.zeros((2, 2, 3), dtype=np.uint8), "boxes": [[0, 0, 1, 1]], "classes": [2]}]
+    test_rows = [{"image": np.zeros((2, 2, 3), dtype=np.uint8), "boxes": [], "classes": []}]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "object_detection", "modality": "text", "hf_id": "dummy"},
+        hf_model_id="dummy/vision",
+        boxes_column="boxes",
+        classes_column="classes",
+    )
+
+    _, y_train = train
+    _, y_test = test
+    assert meta["modality"] == "image"
+    assert meta["task_type"] == "detection"
+    assert meta["hf_task"] == "image_detection"
+    assert y_train[0]["boxes"].shape == (1, 4)
+    assert y_test[0]["boxes"].shape == (0, 4)


### PR DESCRIPTION
### Motivation
- Ensure image preprocessing is selected based on a normalized HF task identity rather than relying solely on `meta["modality"]` so callers can pass `hf_task` directly. 
- Provide a single canonical mapping for image HF tasks and unify task naming across the codebase to avoid alias bugs (e.g. `object_detection` vs `image_detection`).

### Description
- Add a central canonical image task map `IMAGE_TASK_TYPES` and `_IMAGE_TASKS` and resolve image tasks via `_normalize_hf_task` and `_resolve_image_hf_task` before the modality split. 
- Update `preprocess_hf` to dispatch into the image branch when `hf_task` normalizes to an image task, set `meta["hf_task"]`, `meta["modality"] = "image"`, and deterministically derive `task_type` from the canonical image task. 
- Normalize detection naming by changing the HF task spec `name` from `object_detection` to `image_detection` in `mlaas_data_generator/models/adapters/hf_task.py`. 
- Add regression tests in `mlaas_data_generator/test/test_hf_image_preprocessor.py` that verify direct `hf_task`-based image dispatch (including alias normalization like `object_detection`) and make a floating-point augmentation assertion robust by using `np.isclose`.

### Testing
- Installed test deps with `python -m pip install numpy pytest` and ran `PYTHONPATH=. pytest -q mlaas_data_generator/test/test_hf_image_preprocessor.py mlaas_data_generator/test/test_hf_image_task_specs.py mlaas_data_generator/test/test_loader_templates.py`. 
- All targeted tests passed: `10 passed` (after fixing a numeric assertion to use `np.isclose`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf7f50cd448330aae594c5b6ecc0dd)