### PR TITLE
Infer and dispatch multimodal HF tasks to multimodal preprocessor (VQA / retrieval / captioning)

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -10,6 +10,12 @@ from .hf_image import preprocess_hf_image
 from .hf_multimodal import preprocess_hf_multimodal
 
 
+MULTIMODAL_TASK_TYPES = {
+    "text_image_retrieval",
+    "visual_question_answering",
+    "image_captioning",
+}
+
 IMAGE_TASK_TYPES = {
     "image_classification": "classification",
     "image_detection": "detection",
@@ -29,6 +35,9 @@ _EXPECTED_BATCH_KEYS = {
     "image_detection": {"pixel_values"},
     "image_segmentation": {"pixel_values"},
     "multimodal": {"input_ids", "attention_mask", "pixel_values"},
+    "text_image_retrieval": {"input_ids", "attention_mask", "pixel_values"},
+    "visual_question_answering": {"input_ids", "attention_mask", "pixel_values"},
+    "image_captioning": {"input_ids", "attention_mask", "pixel_values"},
 }
 
 _DATASET_TEMPLATE_TO_TASK = {
@@ -65,6 +74,11 @@ def _normalize_hf_task(hf_task):
         "detection": "image_detection",
         "semantic_segmentation": "image_segmentation",
         "segmentation": "image_segmentation",
+        "image_text_retrieval": "text_image_retrieval",
+        "retrieval": "text_image_retrieval",
+        "vqa": "visual_question_answering",
+        "visual_qa": "visual_question_answering",
+        "captioning": "image_captioning",
     }
     return aliases.get(task, task)
 
@@ -126,7 +140,11 @@ def _validate_hf_preprocessor_output(train, test, meta):
 
 def preprocess_hf(train, test, meta, **dataset_args):
     modality = str(meta.get("modality", "text")).strip().lower()
-    hf_task = _resolve_image_hf_task(meta, dataset_args)
+    hf_task = _normalize_hf_task(meta.get("hf_task", dataset_args.get("hf_task", meta.get("task_type"))))
+
+    if hf_task in MULTIMODAL_TASK_TYPES and modality != "multimodal":
+        modality = "multimodal"
+
     hf_model_id = dataset_args.get("hf_model_id")
     if not hf_model_id:
         raise ValueError("HF preprocessing requires hf_model_id in dataset_args")
@@ -162,17 +180,24 @@ def preprocess_hf(train, test, meta, **dataset_args):
         return _validate_hf_preprocessor_output(*out)
 
     if modality == "multimodal":
-        meta["hf_task"] = "multimodal"
+        if hf_task not in MULTIMODAL_TASK_TYPES:
+            hf_task = "multimodal"
+        meta["hf_task"] = hf_task
+        meta["modality"] = "multimodal"
         out = preprocess_hf_multimodal(
             train,
             test,
             meta,
             hf_model_id=hf_model_id,
+            hf_task=hf_task,
             image_column=dataset_args.get("image_column", "image"),
             text_column=dataset_args.get("text_column", "text"),
             label_column=dataset_args.get("label_column"),
             max_length=dataset_args.get("max_length", meta.get("max_length", 128)),
             missing_pair_handling=dataset_args.get("missing_pair_handling", "drop"),
+            question_column=dataset_args.get("question_column"),
+            answer_column=dataset_args.get("answer_column"),
+            ranking_label_column=dataset_args.get("ranking_label_column"),
         )
         return _validate_hf_preprocessor_output(*out)
 

--- a/mlaas_data_generator/data/preprocessors/hf_multimodal.py
+++ b/mlaas_data_generator/data/preprocessors/hf_multimodal.py
@@ -1,6 +1,13 @@
 import numpy as np
 
 
+_TASK_COLUMN_DEFAULTS = {
+    "visual_question_answering": {"text_column": "question", "label_column": "answer"},
+    "text_image_retrieval": {"text_column": "text", "label_column": None},
+    "image_captioning": {"text_column": "text", "label_column": None},
+}
+
+
 def _has_value(value):
     if value is None:
         return False
@@ -116,17 +123,53 @@ def _encode_split(
     return x, y
 
 
+def _resolve_multimodal_columns(
+    hf_task,
+    image_column,
+    text_column,
+    label_column,
+    question_column,
+    answer_column,
+    ranking_label_column,
+):
+    task = str(hf_task or "multimodal").strip().lower().replace("-", "_")
+    defaults = _TASK_COLUMN_DEFAULTS.get(task, {})
+
+    resolved_text_column = text_column
+    resolved_label_column = label_column
+
+    if task == "visual_question_answering":
+        resolved_text_column = question_column or (
+            defaults.get("text_column", "question") if text_column in {None, "", "text"} else text_column
+        )
+        resolved_label_column = answer_column or (
+            defaults.get("label_column", "answer") if label_column in {None, "", "label"} else label_column
+        )
+    elif task == "text_image_retrieval":
+        resolved_text_column = text_column or defaults.get("text_column", "text")
+        resolved_label_column = ranking_label_column if ranking_label_column is not None else label_column
+    elif task == "image_captioning":
+        resolved_text_column = text_column or defaults.get("text_column", "text")
+        resolved_label_column = label_column
+
+    return task, image_column, resolved_text_column, resolved_label_column
+
+
 def preprocess_hf_multimodal(
     train,
     test,
     meta,
     *,
     hf_model_id,
+    hf_task="multimodal",
     image_column="image",
     text_column="text",
     label_column=None,
     max_length=128,
     missing_pair_handling="drop",
+    question_column=None,
+    answer_column=None,
+    ranking_label_column=None,
 ):
     try:
         from transformers import AutoTokenizer, AutoImageProcessor
@@ -139,6 +182,16 @@ def preprocess_hf_multimodal(
 
     ds_train, _ = train
     ds_test, _ = test
+
+    hf_task, image_column, text_column, label_column = _resolve_multimodal_columns(
+        hf_task,
+        image_column,
+        text_column,
+        label_column,
+        question_column,
+        answer_column,
+        ranking_label_column,
+    )
 
     tokenizer = AutoTokenizer.from_pretrained(hf_model_id, use_fast=True)
     image_processor = AutoImageProcessor.from_pretrained(hf_model_id)
@@ -180,6 +233,7 @@ def preprocess_hf_multimodal(
     meta.update(
         {
             "modality": "multimodal",
+            "hf_task": hf_task,
             "hf_processor": hf_model_id,
             "image_column": image_column,
             "text_column": text_column,
@@ -189,6 +243,7 @@ def preprocess_hf_multimodal(
                 "image_column": image_column,
                 "text_column": text_column,
                 "label_column": label_column,
+                "task": hf_task,
                 "pair_validation": {
                     "missing_pair_handling": policy,
                     "train": train_report,

--- a/mlaas_data_generator/test/test_hf_multimodal_schema.py
+++ b/mlaas_data_generator/test/test_hf_multimodal_schema.py
@@ -29,12 +29,16 @@ class DummyDS:
 
 
 def test_hf_source_multimodal_pair_drop(monkeypatch):
-    ds = DummyDS([
+    train_ds = DummyDS([
         {"image": np.zeros((8, 8, 3), dtype=np.uint8), "text": "a", "label": 0},
         {"image": None, "text": "b", "label": 1},
+    ])
+    test_ds = DummyDS([
         {"image": np.zeros((8, 8, 3), dtype=np.uint8), "text": "c", "label": 1},
     ])
-    fake_mod = types.SimpleNamespace(load_dataset=lambda *args, **kwargs: ds)
+    fake_mod = types.SimpleNamespace(
+        load_dataset=lambda *args, **kwargs: train_ds if kwargs.get("split") == "train" else test_ds
+    )
     monkeypatch.setitem(sys.modules, "datasets", fake_mod)
 
     (train, _), (test, _), meta = load_huggingface_source(
@@ -89,3 +93,119 @@ def test_hf_multimodal_preprocessor_contract(monkeypatch):
     assert set(x_train.keys()) == {"input_ids", "attention_mask", "pixel_values"}
     assert x_train["input_ids"].shape[0] == x_train["pixel_values"].shape[0] == len(y_train)
     assert meta["schema"]["batch_contract"]["combined_keys"] == ["input_ids", "attention_mask", "pixel_values"]
+
+
+
+def test_preprocess_hf_dispatches_vqa_without_multimodal_metadata(monkeypatch):
+    from mlaas_data_generator.data.preprocessors import hf as hf_preprocessors
+
+    captured = {}
+
+    def _stub(train, test, meta, **kwargs):
+        captured["meta"] = dict(meta)
+        captured["kwargs"] = dict(kwargs)
+        return (
+            {
+                "input_ids": np.array([[1, 2]]),
+                "attention_mask": np.array([[1, 1]]),
+                "pixel_values": np.ones((1, 3, 2, 2), dtype=np.float32),
+            },
+            np.array([1]),
+        ), (
+            {
+                "input_ids": np.array([[3, 4]]),
+                "attention_mask": np.array([[1, 1]]),
+                "pixel_values": np.ones((1, 3, 2, 2), dtype=np.float32),
+            },
+            np.array([0]),
+        ), meta
+
+    monkeypatch.setattr(hf_preprocessors, "preprocess_hf_multimodal", _stub)
+
+    (_, _), (_, _), meta = hf_preprocessors.preprocess_hf(
+        (DummyDS([{"image": np.ones((2, 2, 3), dtype=np.uint8), "question": "q", "answer": "a"}]), None),
+        (DummyDS([{"image": np.ones((2, 2, 3), dtype=np.uint8), "question": "q2", "answer": "a2"}]), None),
+        {"hf_task": "visual_question_answering"},
+        hf_model_id="dummy/model",
+    )
+
+    assert meta["modality"] == "multimodal"
+    assert meta["hf_task"] == "visual_question_answering"
+    assert captured["kwargs"]["hf_task"] == "visual_question_answering"
+
+
+
+def test_preprocess_hf_dispatches_retrieval_without_multimodal_metadata(monkeypatch):
+    from mlaas_data_generator.data.preprocessors import hf as hf_preprocessors
+
+    captured = {}
+
+    def _stub(train, test, meta, **kwargs):
+        captured["meta"] = dict(meta)
+        captured["kwargs"] = dict(kwargs)
+        return (
+            {
+                "input_ids": np.array([[1, 2]]),
+                "attention_mask": np.array([[1, 1]]),
+                "pixel_values": np.ones((1, 3, 2, 2), dtype=np.float32),
+            },
+            np.array([0]),
+        ), (
+            {
+                "input_ids": np.array([[3, 4]]),
+                "attention_mask": np.array([[1, 1]]),
+                "pixel_values": np.ones((1, 3, 2, 2), dtype=np.float32),
+            },
+            np.array([0]),
+        ), meta
+
+    monkeypatch.setattr(hf_preprocessors, "preprocess_hf_multimodal", _stub)
+
+    (_, _), (_, _), meta = hf_preprocessors.preprocess_hf(
+        (DummyDS([{"image": np.ones((2, 2, 3), dtype=np.uint8), "text": "caption"}]), None),
+        (DummyDS([{"image": np.ones((2, 2, 3), dtype=np.uint8), "text": "caption 2"}]), None),
+        {"hf_task": "text_image_retrieval"},
+        hf_model_id="dummy/model",
+    )
+
+    assert meta["modality"] == "multimodal"
+    assert meta["hf_task"] == "text_image_retrieval"
+    assert captured["kwargs"]["hf_task"] == "text_image_retrieval"
+
+
+
+def test_hf_multimodal_vqa_defaults(monkeypatch):
+    train = DummyDS([
+        {"image": np.ones((8, 8, 3), dtype=np.uint8), "question": "what?", "answer": "cat"},
+    ])
+    test = DummyDS([
+        {"image": np.ones((8, 8, 3), dtype=np.uint8), "question": "where?", "answer": "home"},
+    ])
+
+    class DummyTokenizer:
+        def __call__(self, text, **kwargs):
+            return {"input_ids": [1, 2, 3, 0], "attention_mask": [1, 1, 1, 0]}
+
+    class DummyImageProcessor:
+        def __call__(self, image, **kwargs):
+            chw = np.transpose(np.asarray(image, dtype=np.float32), (2, 0, 1))
+            return {"pixel_values": chw}
+
+    fake_tr = types.SimpleNamespace(
+        AutoTokenizer=types.SimpleNamespace(from_pretrained=lambda *a, **k: DummyTokenizer()),
+        AutoImageProcessor=types.SimpleNamespace(from_pretrained=lambda *a, **k: DummyImageProcessor()),
+    )
+    monkeypatch.setitem(sys.modules, "transformers", fake_tr)
+
+    (_, y_train), (_, y_test), meta = preprocess_hf_multimodal(
+        (train, None),
+        (test, None),
+        {},
+        hf_model_id="dummy/model",
+        hf_task="visual_question_answering",
+    )
+
+    assert y_train.tolist() == ["cat"]
+    assert y_test.tolist() == ["home"]
+    assert meta["text_column"] == "question"
+    assert meta["label_column"] == "answer"


### PR DESCRIPTION
### Motivation
- Ensure HF multimodal tasks are recognized and routed into the multimodal preprocessing path even when `meta["modality"]` or modality metadata are missing or incomplete.
- Preserve task-specific semantics (VQA / retrieval / captioning) so defaults and schema information (e.g. question/answer columns or ranking labels) can be applied without changing the shared multimodal encoding path.

### Description
- Add a canonical set `MULTIMODAL_TASK_TYPES` containing `text_image_retrieval`, `visual_question_answering`, and `image_captioning`, plus alias mappings so common short names (`vqa`, `retrieval`, `captioning`, etc.) normalize to these tasks in `_normalize_hf_task`.
- Infer `modality="multimodal"` in `preprocess_hf` when the normalized `hf_task` is one of the canonical multimodal tasks and route execution into `preprocess_hf_multimodal` while preserving the specific `hf_task` name.
- Extend `_EXPECTED_BATCH_KEYS` to include the canonical multimodal task names to support validation by exact `meta["hf_task"]`.
- Enhance `preprocess_hf_multimodal` with a thin task-aware column resolver: introduce `_TASK_COLUMN_DEFAULTS` and `_resolve_multimodal_columns` to apply sensible defaults and to resolve `question`/`answer` for VQA, text column and optional ranking label for retrieval, and captioning defaults, without changing the unified encoding/encoding contract.
- Add thin `hf_task` passthrough and extra keyword args (`question_column`, `answer_column`, `ranking_label_column`) so `preprocess_hf_multimodal` can receive task-specific hints.
- Tests: update the multimodal source test fixture to provide distinct train/test stubs and add regression tests that verify direct dispatch for `visual_question_answering` and `text_image_retrieval`, plus a VQA-defaults test that checks question/answer column resolution.
- Files changed: `mlaas_data_generator/data/preprocessors/hf.py`, `mlaas_data_generator/data/preprocessors/hf_multimodal.py`, and `mlaas_data_generator/test/test_hf_multimodal_schema.py`.

### Testing
- Ran the targeted test suite with `PYTHONPATH=. pytest -q mlaas_data_generator/test/test_hf_multimodal_schema.py mlaas_data_generator/test/test_loader_templates.py`, and all tests passed: `7 passed`.
- The multimodal contract tests confirm multimodal dispatch and VQA/retrieval defaults and the loader-template dispatch tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf802c55988330bf53348394d6af5b)