### PR TITLE
Centralize HF task normalization

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -8,19 +8,16 @@ from .hf_text_generation import (
 )
 from .hf_image import preprocess_hf_image
 from .hf_multimodal import preprocess_hf_multimodal
+from ...hf_tasks import (
+    HF_TASK_MODALITY,
+    IMAGE_TASK_TYPES,
+    normalize_hf_task,
+    resolve_dataset_hf_task,
+    resolve_hf_task_spec,
+)
 
 
-MULTIMODAL_TASK_TYPES = {
-    "text_image_retrieval",
-    "visual_question_answering",
-    "image_captioning",
-}
-
-IMAGE_TASK_TYPES = {
-    "image_classification": "classification",
-    "image_detection": "detection",
-    "image_segmentation": "segmentation",
-}
+_MULTIMODAL_TASKS = frozenset(task for task, modality in HF_TASK_MODALITY.items() if modality == "multimodal" and task != "multimodal")
 _IMAGE_TASKS = frozenset(IMAGE_TASK_TYPES)
 
 
@@ -40,71 +37,19 @@ _EXPECTED_BATCH_KEYS = {
     "image_captioning": {"input_ids", "attention_mask", "pixel_values"},
 }
 
-_DATASET_TEMPLATE_TO_TASK = {
-    "hf_text_classification": "sequence_classification",
-    "hf_token_classification": "token_classification",
-    "hf_sentence_pair_classification": "sentence_similarity",
-    "hf_masked_lm": "fill_mask",
-    "hf_causal_lm": "causal_lm_generation",
-    "hf_seq2seq": "seq2seq_generation",
-    # backwards compatibility
-    "hf_text_sequence": "sequence_classification",
-    "hf_text_token": "token_classification",
-    "hf_text_similarity": "sentence_similarity",
-    "hf_text_fill_mask": "fill_mask",
-    "hf_text_generation": None,
-}
-
-
-def _normalize_hf_task(hf_task):
-    task = str(hf_task or "sequence_classification").strip().lower().replace("-", "_")
-    aliases = {
-        "text_classification": "sequence_classification",
-        "seq_cls": "sequence_classification",
-        "token_cls": "token_classification",
-        "masked_lm": "fill_mask",
-        "mlm": "fill_mask",
-        "text_generation": "causal_lm_generation",
-        "causal_lm": "causal_lm_generation",
-        "text2text": "seq2seq_generation",
-        "text2text_generation": "seq2seq_generation",
-        "vision_classification": "image_classification",
-        "image_cls": "image_classification",
-        "object_detection": "image_detection",
-        "detection": "image_detection",
-        "semantic_segmentation": "image_segmentation",
-        "segmentation": "image_segmentation",
-        "image_text_retrieval": "text_image_retrieval",
-        "retrieval": "text_image_retrieval",
-        "vqa": "visual_question_answering",
-        "visual_qa": "visual_question_answering",
-        "captioning": "image_captioning",
-    }
-    return aliases.get(task, task)
-
-
 def _resolve_dataset_loader_template(meta, dataset_args):
     dataset_meta = meta.get("dataset_args") if isinstance(meta.get("dataset_args"), dict) else {}
     template = dataset_args.get("loader_template") or meta.get("loader_template") or dataset_meta.get("loader_template")
     return str(template).strip().lower() if template else None
 
 
-def _resolve_image_hf_task(meta, dataset_args):
-    return _normalize_hf_task(meta.get("hf_task", dataset_args.get("hf_task", meta.get("task_type"))))
-
-
 def _resolve_text_hf_task(meta, dataset_args):
-    template = _resolve_dataset_loader_template(meta, dataset_args)
-    if template == "hf_text_generation":
-        task_tag = str(meta.get("task_tag") or dataset_args.get("task_tag") or "").strip().lower().replace("-", "_")
-        pipeline_tag = str(meta.get("pipeline_tag") or dataset_args.get("pipeline_tag") or "").strip().lower()
-        if task_tag in {"summarization", "translation", "seq2seq", "text2text"} or pipeline_tag == "text2text-generation":
-            return "seq2seq_generation"
-        return "causal_lm_generation"
-    mapped = _DATASET_TEMPLATE_TO_TASK.get(template)
-    if mapped:
-        return mapped
-    return _normalize_hf_task(meta.get("hf_task", dataset_args.get("hf_task", "sequence_classification")))
+    return resolve_dataset_hf_task(
+        loader_template=_resolve_dataset_loader_template(meta, dataset_args),
+        hf_task=meta.get("hf_task", dataset_args.get("hf_task", "sequence_classification")),
+        task_tag=meta.get("task_tag") or dataset_args.get("task_tag"),
+        pipeline_tag=meta.get("pipeline_tag") or dataset_args.get("pipeline_tag"),
+    )
 
 
 def _validate_hf_preprocessor_output(train, test, meta):
@@ -139,25 +84,25 @@ def _validate_hf_preprocessor_output(train, test, meta):
 
 
 def preprocess_hf(train, test, meta, **dataset_args):
-    modality = str(meta.get("modality", "text")).strip().lower()
-    hf_task = _normalize_hf_task(meta.get("hf_task", dataset_args.get("hf_task", meta.get("task_type"))))
-
-    if hf_task in MULTIMODAL_TASK_TYPES and modality != "multimodal":
-        modality = "multimodal"
+    requested_modality = str(meta.get("modality", "text")).strip().lower()
+    requested_task = meta.get("hf_task", dataset_args.get("hf_task", meta.get("task_type")))
+    hf_task = normalize_hf_task(requested_task)
+    canonical_modality = HF_TASK_MODALITY.get(hf_task)
+    modality = requested_modality if requested_modality in {"image", "multimodal"} else (canonical_modality or requested_modality)
 
     hf_model_id = dataset_args.get("hf_model_id")
     if not hf_model_id:
         raise ValueError("HF preprocessing requires hf_model_id in dataset_args")
 
-    if hf_task in _IMAGE_TASKS or modality == "image":
-        if hf_task in _IMAGE_TASKS:
-            task_type = IMAGE_TASK_TYPES[hf_task]
-        else:
+    if modality == "image":
+        if hf_task not in _IMAGE_TASKS:
             task_type = str(meta.get("task_type", "classification")).strip().lower()
-            hf_task = _normalize_hf_task(f"image_{task_type}")
-            if hf_task not in _IMAGE_TASKS:
-                raise ValueError(f"Unsupported HF image task: {hf_task}")
-            task_type = IMAGE_TASK_TYPES[hf_task]
+            hf_task = normalize_hf_task(f"image_{task_type}")
+        task_spec = resolve_hf_task_spec(hf_task)
+        if task_spec.hf_task not in _IMAGE_TASKS:
+            raise ValueError(f"Unsupported HF image task: {hf_task}")
+        hf_task = task_spec.hf_task
+        task_type = task_spec.task_type
         meta["hf_task"] = hf_task
         meta["modality"] = "image"
         meta["task_type"] = task_type
@@ -180,7 +125,7 @@ def preprocess_hf(train, test, meta, **dataset_args):
         return _validate_hf_preprocessor_output(*out)
 
     if modality == "multimodal":
-        if hf_task not in MULTIMODAL_TASK_TYPES:
+        if hf_task not in _MULTIMODAL_TASKS:
             hf_task = "multimodal"
         meta["hf_task"] = hf_task
         meta["modality"] = "multimodal"

--- a/mlaas_data_generator/federated/strategies/base.py
+++ b/mlaas_data_generator/federated/strategies/base.py
@@ -1,6 +1,7 @@
 #base.p
 from dataclasses import dataclass
 import numpy as np
+from ...hf_tasks import normalize_hf_task as shared_normalize_hf_task
 from ...models.label_schema import infer_num_labels
 
 
@@ -33,32 +34,7 @@ def _nanmean(values):
 
 def normalize_hf_task(hf_task: str | None) -> str:
     """Normalize user/provider HF task aliases to canonical names."""
-    task = (hf_task or "").strip().lower().replace("-", "_")
-    mapping = {
-        "text_classification": "sequence_classification",
-        "seq_cls": "sequence_classification",
-        "sequence_cls": "sequence_classification",
-        "token_cls": "token_classification",
-        "ner": "token_classification",
-        "masked_lm": "fill_mask",
-        "mlm": "fill_mask",
-        "text_generation": "causal_lm_generation",
-        "causal_lm": "causal_lm_generation",
-        "text2text": "seq2seq_generation",
-        "text2text_generation": "seq2seq_generation",
-        "vision_classification": "image_classification",
-        "image_cls": "image_classification",
-        "object_detection": "image_detection",
-        "detection": "image_detection",
-        "semantic_segmentation": "image_segmentation",
-        "segmentation": "image_segmentation",
-        "image_to_text": "image_captioning",
-        "image_caption": "image_captioning",
-        "image_text_retrieval": "text_image_retrieval",
-        "retrieval": "text_image_retrieval",
-        "vqa": "visual_question_answering",
-    }
-    return mapping.get(task, task or "unknown")
+    return shared_normalize_hf_task(hf_task, default="unknown", unknown="unknown")
 
 
 def canonical_task_family(task_type: str | None, hf_task: str | None = None) -> str:
@@ -138,7 +114,7 @@ def canonical_generation_metrics(task_tag: str | None, has_labels: bool) -> tupl
         base = ("rouge1", "rouge2", "rougeL")
     elif tag == "translation":
         base = ("sacrebleu",)
-    elif tag in {"captioning", "image_captioning", "image_to_text"}:
+    elif tag in {"captioning", "image_captioning"}:
         base = ("cider", "bleu")
     else:
         base = tuple()

--- a/mlaas_data_generator/hf_tasks.py
+++ b/mlaas_data_generator/hf_tasks.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DEFAULT_HF_TASK = "sequence_classification"
+UNKNOWN_HF_TASK = "unknown"
+
+CANONICAL_HF_TASKS = frozenset({
+    "sequence_classification",
+    "token_classification",
+    "sentence_similarity",
+    "fill_mask",
+    "causal_lm_generation",
+    "seq2seq_generation",
+    "image_classification",
+    "image_detection",
+    "image_segmentation",
+    "image_captioning",
+    "text_image_retrieval",
+    "visual_question_answering",
+    "multimodal",
+})
+
+HF_TASK_ALIASES = {
+    "text_classification": "sequence_classification",
+    "seq_cls": "sequence_classification",
+    "sequence_cls": "sequence_classification",
+    "token_cls": "token_classification",
+    "ner": "token_classification",
+    "masked_lm": "fill_mask",
+    "mlm": "fill_mask",
+    "text_generation": "causal_lm_generation",
+    "causal_lm": "causal_lm_generation",
+    "text2text": "seq2seq_generation",
+    "text2text_generation": "seq2seq_generation",
+    "vision_classification": "image_classification",
+    "image_cls": "image_classification",
+    "object_detection": "image_detection",
+    "detection": "image_detection",
+    "semantic_segmentation": "image_segmentation",
+    "segmentation": "image_segmentation",
+    "image_to_text": "image_captioning",
+    "image_caption": "image_captioning",
+    "captioning": "image_captioning",
+    "image_text_retrieval": "text_image_retrieval",
+    "retrieval": "text_image_retrieval",
+    "vqa": "visual_question_answering",
+    "visual_qa": "visual_question_answering",
+}
+
+HF_TASK_MODALITY = {
+    "sequence_classification": "text",
+    "token_classification": "text",
+    "sentence_similarity": "text",
+    "fill_mask": "text",
+    "causal_lm_generation": "text",
+    "seq2seq_generation": "text",
+    "image_classification": "image",
+    "image_detection": "image",
+    "image_segmentation": "image",
+    "image_captioning": "multimodal",
+    "text_image_retrieval": "multimodal",
+    "visual_question_answering": "multimodal",
+    "multimodal": "multimodal",
+}
+
+IMAGE_TASK_TYPES = {
+    "image_classification": "classification",
+    "image_detection": "detection",
+    "image_segmentation": "segmentation",
+}
+
+MULTIMODAL_TASK_TAGS = {
+    "image_captioning": "captioning",
+    "text_image_retrieval": "retrieval",
+    "visual_question_answering": "vqa",
+}
+
+PIPELINE_TAG_TO_HF_TASK = {
+    "text-classification": "sequence_classification",
+    "token-classification": "token_classification",
+    "sentence-similarity": "sentence_similarity",
+    "fill-mask": "fill_mask",
+    "text-generation": "causal_lm_generation",
+    "text2text-generation": "seq2seq_generation",
+    "image-classification": "image_classification",
+    "object-detection": "image_detection",
+    "image-segmentation": "image_segmentation",
+    "image-to-text": "image_captioning",
+    "zero-shot-image-classification": "text_image_retrieval",
+    "visual-question-answering": "visual_question_answering",
+}
+
+MODEL_TEMPLATE_TO_HF_TASK = {
+    "hf_sequence_classification": "sequence_classification",
+    "hf_token_classification": "token_classification",
+    "hf_sentence_similarity": "sentence_similarity",
+    "hf_fill_mask": "fill_mask",
+    "hf_causal_lm": "causal_lm_generation",
+    "hf_seq2seq": "seq2seq_generation",
+    "auto_sequence_classification": "sequence_classification",
+    "auto_token_classification": "token_classification",
+    "auto_masked_lm": "fill_mask",
+    "auto_causal_lm": "causal_lm_generation",
+    "auto_seq2seq_lm": "seq2seq_generation",
+}
+
+DATASET_TEMPLATE_TO_HF_TASK = {
+    "hf_text_classification": "sequence_classification",
+    "hf_token_classification": "token_classification",
+    "hf_sentence_pair_classification": "sentence_similarity",
+    "hf_masked_lm": "fill_mask",
+    "hf_causal_lm": "causal_lm_generation",
+    "hf_seq2seq": "seq2seq_generation",
+    "hf_text_sequence": "sequence_classification",
+    "hf_text_token": "token_classification",
+    "hf_text_similarity": "sentence_similarity",
+    "hf_text_fill_mask": "fill_mask",
+    "hf_text_generation": None,
+}
+
+@dataclass(frozen=True)
+class HfTaskSpec:
+    hf_task: str
+    modality: str
+    task_type: str | None = None
+    task_tag: str | None = None
+
+
+def normalize_hf_task(hf_task: str | None, *, default: str = DEFAULT_HF_TASK, unknown: str | None = None) -> str:
+    task = str(hf_task or "").strip().lower().replace("-", "_")
+    if not task:
+        return default
+    normalized = HF_TASK_ALIASES.get(task, task)
+    if normalized in CANONICAL_HF_TASKS:
+        return normalized
+    return unknown if unknown is not None else normalized
+
+
+def hf_task_modality(hf_task: str | None, *, default: str | None = None) -> str | None:
+    return HF_TASK_MODALITY.get(normalize_hf_task(hf_task), default)
+
+
+def hf_task_type(hf_task: str | None, *, default: str | None = None) -> str | None:
+    return IMAGE_TASK_TYPES.get(normalize_hf_task(hf_task), default)
+
+
+def hf_task_tag(hf_task: str | None, *, default: str | None = None) -> str | None:
+    return MULTIMODAL_TASK_TAGS.get(normalize_hf_task(hf_task), default)
+
+
+def resolve_hf_task_spec(hf_task: str | None, *, default: str = DEFAULT_HF_TASK, unknown: str | None = None) -> HfTaskSpec:
+    task = normalize_hf_task(hf_task, default=default, unknown=unknown)
+    return HfTaskSpec(
+        hf_task=task,
+        modality=HF_TASK_MODALITY.get(task, "text" if task != unknown else "unknown"),
+        task_type=IMAGE_TASK_TYPES.get(task),
+        task_tag=MULTIMODAL_TASK_TAGS.get(task),
+    )
+
+
+def normalize_loader_template(loader_template: str | None) -> str | None:
+    if not loader_template:
+        return None
+    return str(loader_template).strip().lower()
+
+
+def resolve_model_hf_task(loader_template: str | None = None, hf_task: str | None = None) -> str:
+    template = normalize_loader_template(loader_template)
+    mapped = MODEL_TEMPLATE_TO_HF_TASK.get(template)
+    if mapped:
+        return mapped
+    return normalize_hf_task(hf_task)
+
+
+def resolve_dataset_hf_task(loader_template: str | None = None, hf_task: str | None = None, *, task_tag: str | None = None, pipeline_tag: str | None = None) -> str:
+    template = normalize_loader_template(loader_template)
+    if template == "hf_text_generation":
+        normalized_task_tag = str(task_tag or "").strip().lower().replace("-", "_")
+        normalized_pipeline_tag = str(pipeline_tag or "").strip().lower()
+        if normalized_task_tag in {"summarization", "translation", "seq2seq", "text2text"} or normalized_pipeline_tag == "text2text-generation":
+            return "seq2seq_generation"
+        return "causal_lm_generation"
+    mapped = DATASET_TEMPLATE_TO_HF_TASK.get(template)
+    if mapped:
+        return mapped
+    return normalize_hf_task(hf_task)

--- a/mlaas_data_generator/models/adapters/hf_adapter.py
+++ b/mlaas_data_generator/models/adapters/hf_adapter.py
@@ -1,5 +1,6 @@
 from .hf_core import HFCore
 from .hf_cache import get_cached_model
+from ...hf_tasks import resolve_model_hf_task
 from .hf_task import (
     SequenceClassificationSpec,
     SentenceSimilaritySpec,
@@ -16,50 +17,8 @@ from .hf_task import (
 )
 
 
-def _normalize_hf_task_name(hf_task):
-    task = str(hf_task or "sequence_classification").strip().lower().replace("-", "_")
-    aliases = {
-        "text_classification": "sequence_classification",
-        "seq_cls": "sequence_classification",
-        "token_cls": "token_classification",
-        "masked_lm": "fill_mask",
-        "mlm": "fill_mask",
-        "text_generation": "causal_lm_generation",
-        "causal_lm": "causal_lm_generation",
-        "text2text": "seq2seq_generation",
-        "text2text_generation": "seq2seq_generation",
-        "vision_classification": "image_classification",
-        "image_cls": "image_classification",
-        "object_detection": "image_detection",
-        "detection": "image_detection",
-        "semantic_segmentation": "image_segmentation",
-        "segmentation": "image_segmentation",
-    }
-    return aliases.get(task, task)
-
-
-_MODEL_TEMPLATE_TO_TASK = {
-    "hf_sequence_classification": "sequence_classification",
-    "hf_token_classification": "token_classification",
-    "hf_sentence_similarity": "sentence_similarity",
-    "hf_fill_mask": "fill_mask",
-    "hf_causal_lm": "causal_lm_generation",
-    "hf_seq2seq": "seq2seq_generation",
-    # backwards compatibility
-    "auto_sequence_classification": "sequence_classification",
-    "auto_token_classification": "token_classification",
-    "auto_masked_lm": "fill_mask",
-    "auto_causal_lm": "causal_lm_generation",
-    "auto_seq2seq_lm": "seq2seq_generation",
-}
-
-
 def resolve_hf_task(loader_template=None, hf_task=None):
-    template = str(loader_template).strip().lower() if loader_template else None
-    mapped = _MODEL_TEMPLATE_TO_TASK.get(template)
-    if mapped:
-        return mapped
-    return _normalize_hf_task_name(hf_task)
+    return resolve_model_hf_task(loader_template=loader_template, hf_task=hf_task)
 
 
 def build_task_spec(hf_task=None, *, loader_template=None, num_labels=None, multilabel=False, label_format="single_index"):
@@ -76,17 +35,17 @@ def build_task_spec(hf_task=None, *, loader_template=None, num_labels=None, mult
         return task, CausalLMGenerationSpec()
     if task == "seq2seq_generation":
         return task, Seq2SeqGenerationSpec()
-    if task in {"image_classification", "vision_classification"}:
+    if task == "image_classification":
         return "image_classification", ImageClassificationSpec()
-    if task in {"object_detection", "image_detection", "detection"}:
+    if task == "image_detection":
         return "image_detection", ObjectDetectionSpec()
-    if task in {"image_segmentation", "semantic_segmentation", "segmentation"}:
+    if task == "image_segmentation":
         return "image_segmentation", ImageSegmentationSpec()
-    if task in {"image_captioning", "image_to_text"}:
+    if task == "image_captioning":
         return "image_captioning", ImageCaptioningSpec()
-    if task in {"text_image_retrieval", "image_text_retrieval"}:
+    if task == "text_image_retrieval":
         return "text_image_retrieval", TextImageRetrievalSpec()
-    if task in {"visual_question_answering", "vqa"}:
+    if task == "visual_question_answering":
         return "visual_question_answering", VQASpec()
     return "sequence_classification", SequenceClassificationSpec(multilabel=multilabel, label_format=label_format)
 

--- a/mlaas_data_generator/test/test_loader_templates.py
+++ b/mlaas_data_generator/test/test_loader_templates.py
@@ -58,3 +58,22 @@ def test_model_loader_templates_override_legacy_hf_task():
     task, spec = build_task_spec("fill_mask", loader_template="hf_sentence_similarity", num_labels=1, label_format="continuous")
     assert task == "sentence_similarity"
     assert spec.name == "sentence_similarity"
+
+
+
+def test_aliases_normalize_identically_across_preprocess_and_model_paths():
+    aliases = {
+        "object_detection": "image_detection",
+        "detection": "image_detection",
+        "semantic_segmentation": "image_segmentation",
+        "segmentation": "image_segmentation",
+        "image_to_text": "image_captioning",
+        "retrieval": "text_image_retrieval",
+        "vqa": "visual_question_answering",
+    }
+
+    for alias, canonical in aliases.items():
+        assert hf_preprocessors.normalize_hf_task(alias) == canonical
+        assert resolve_hf_task(hf_task=alias) == canonical
+
+

--- a/scrubber/scrub.py
+++ b/scrubber/scrub.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from huggingface_hub import HfApi
 
+from mlaas_data_generator.hf_tasks import PIPELINE_TAG_TO_HF_TASK, resolve_hf_task_spec
+
 
 @dataclass(frozen=True)
 class TaskSpec:
@@ -17,64 +19,27 @@ class TaskSpec:
 
 
 TASK_SPECS: dict[str, TaskSpec] = {
-    "text_classification": TaskSpec(
-        pipeline_tag="text-classification",
-        hf_task="sequence_classification",
-    ),
-    "token_classification": TaskSpec(
-        pipeline_tag="token-classification",
-        hf_task="token_classification",
-    ),
-    "sentence_similarity": TaskSpec(
-        pipeline_tag="sentence-similarity",
-        hf_task="sentence_similarity",
-    ),
-    "fill_mask": TaskSpec(
-        pipeline_tag="fill-mask",
-        hf_task="fill_mask",
-    ),
-    "text_generation": TaskSpec(
-        pipeline_tag="text-generation",
-        hf_task="causal_lm_generation",
-        task_tag="language-modeling",
-    ),
-    "text2text_generation": TaskSpec(
-        pipeline_tag="text2text-generation",
-        hf_task="seq2seq_generation",
-    ),
-    "image_classification": TaskSpec(
-        pipeline_tag="image-classification",
-        hf_task="image_classification",
-        modality="image",
-    ),
-    "object_detection": TaskSpec(
-        pipeline_tag="object-detection",
-        hf_task="object_detection",
-        modality="image",
-    ),
-    "image_segmentation": TaskSpec(
-        pipeline_tag="image-segmentation",
-        hf_task="image_segmentation",
-        modality="image",
-    ),
-    "image_captioning": TaskSpec(
-        pipeline_tag="image-to-text",
-        hf_task="image_captioning",
-        modality="multimodal",
-        task_tag="captioning",
-    ),
-    "text_image_retrieval": TaskSpec(
-        pipeline_tag="zero-shot-image-classification",
-        hf_task="text_image_retrieval",
-        modality="multimodal",
-        task_tag="retrieval",
-    ),
-    "visual_question_answering": TaskSpec(
-        pipeline_tag="visual-question-answering",
-        hf_task="visual_question_answering",
-        modality="multimodal",
-        task_tag="vqa",
-    ),
+    task_key: TaskSpec(
+        pipeline_tag=pipeline_tag,
+        hf_task=spec.hf_task,
+        modality=spec.modality,
+        task_tag=("language-modeling" if spec.hf_task == "causal_lm_generation" else spec.task_tag),
+    )
+    for pipeline_tag, task_key in (
+        ("text-classification", "text_classification"),
+        ("token-classification", "token_classification"),
+        ("sentence-similarity", "sentence_similarity"),
+        ("fill-mask", "fill_mask"),
+        ("text-generation", "text_generation"),
+        ("text2text-generation", "text2text_generation"),
+        ("image-classification", "image_classification"),
+        ("object-detection", "object_detection"),
+        ("image-segmentation", "image_segmentation"),
+        ("image-to-text", "image_captioning"),
+        ("zero-shot-image-classification", "text_image_retrieval"),
+        ("visual-question-answering", "visual_question_answering"),
+    )
+    for spec in (resolve_hf_task_spec(PIPELINE_TAG_TO_HF_TASK[pipeline_tag]),)
 }
 
 


### PR DESCRIPTION
### Motivation
- Eliminate duplicated HF task alias maps spread across preprocessors, adapters, federated code, and the scrubber by providing a single shared resolver and metadata registry. 
- Ensure a single canonical naming for image detection/segmentation and consistent modality inference so dispatch and metric logic behave the same across code paths.

### Description
- Added a shared module `mlaas_data_generator/hf_tasks.py` that defines canonical HF tasks, aliases, modality mapping, image task-type mapping, pipeline/loader-template resolution helpers, and `HfTaskSpec` helpers. 
- Refactored `data/preprocessors/hf.py` to use the shared `normalize_hf_task`, `resolve_dataset_hf_task`, `resolve_hf_task_spec`, and `HF_TASK_MODALITY` so preprocessing dispatch is driven by canonical task + modality. 
- Updated the HF adapter resolution in `models/adapters/hf_adapter.py` to use the shared model-template resolver (`resolve_model_hf_task`) and removed the local alias map. 
- Replaced the local normalization in `federated/strategies/base.py` with the shared normalizer to keep task-family and metric logic consistent. 
- Reworked `scrubber/scrub.py` to derive task specs from the shared registry instead of hardcoding per-task mappings. 
- Added a unit test in `mlaas_data_generator/test/test_loader_templates.py` that asserts important aliases (e.g. `object_detection` / `detection`, `segmentation`) normalize identically across preprocessing and model-building paths.

### Testing
- Compiled the package modules with `python -m compileall mlaas_data_generator scrubber`, which completed successfully. 
- Ran the focused test suite with `PYTHONPATH=. pytest -q mlaas_data_generator/test/test_loader_templates.py mlaas_data_generator/test/test_hf_image_preprocessor.py mlaas_data_generator/test/test_hf_multimodal_schema.py mlaas_data_generator/test/test_hf_multimodal_task_specs.py`, and all tests passed (`16 passed`).
- The new alias-consistency unit test passed as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf816cd3ac8330a51f71ea001baf93)