### PR TITLE
Fix HF generation padding and distribution summaries

### DIFF
--- a/mlaas_data_generator/data/distributions.py
+++ b/mlaas_data_generator/data/distributions.py
@@ -49,6 +49,86 @@ def get_mlm_masked_token_stats(y, *, ignore_index=-100, top_k=10):
         "top_masked_token_ids": top,
     }
 
+
+
+def get_token_label_stats(y, *, ignore_index=-100, pad_token_id=None, top_k=10):
+    """Return summary stats for token-label tasks like generation."""
+    if y is None:
+        return {
+            "total_tokens": 0,
+            "supervised_tokens": 0,
+            "supervised_ratio": 0.0,
+            "unique_supervised_token_ids": 0,
+            "top_supervised_token_ids": {},
+        }
+
+    y_arr = np.asarray(y)
+    if y_arr.size == 0:
+        return {
+            "total_tokens": 0,
+            "supervised_tokens": 0,
+            "supervised_ratio": 0.0,
+            "unique_supervised_token_ids": 0,
+            "top_supervised_token_ids": {},
+        }
+
+    y_flat = y_arr.reshape(-1)
+    total_tokens = int(y_flat.size)
+
+    mask = np.ones(total_tokens, dtype=bool)
+    if ignore_index is not None:
+        mask &= (y_flat != int(ignore_index))
+    if pad_token_id is not None:
+        mask &= (y_flat != int(pad_token_id))
+
+    supervised = y_flat[mask]
+    supervised_tokens = int(supervised.size)
+    supervised_ratio = float(supervised_tokens / max(1, total_tokens))
+
+    if supervised_tokens == 0:
+        return {
+            "total_tokens": total_tokens,
+            "supervised_tokens": 0,
+            "supervised_ratio": supervised_ratio,
+            "unique_supervised_token_ids": 0,
+            "top_supervised_token_ids": {},
+        }
+
+    try:
+        supervised = supervised.astype("int64", copy=False)
+    except Exception:
+        cleaned = []
+        for token in supervised:
+            if token is None:
+                continue
+            try:
+                cleaned.append(int(token))
+            except Exception:
+                continue
+        supervised = np.asarray(cleaned, dtype="int64")
+        supervised_tokens = int(supervised.size)
+        supervised_ratio = float(supervised_tokens / max(1, total_tokens))
+        if supervised_tokens == 0:
+            return {
+                "total_tokens": total_tokens,
+                "supervised_tokens": 0,
+                "supervised_ratio": supervised_ratio,
+                "unique_supervised_token_ids": 0,
+                "top_supervised_token_ids": {},
+            }
+
+    token_ids, counts = np.unique(supervised, return_counts=True)
+    order = np.argsort(counts)[::-1][: int(top_k)]
+    top = {int(token_ids[i]): int(counts[i]) for i in order}
+
+    return {
+        "total_tokens": total_tokens,
+        "supervised_tokens": supervised_tokens,
+        "supervised_ratio": supervised_ratio,
+        "unique_supervised_token_ids": int(token_ids.size),
+        "top_supervised_token_ids": top,
+    }
+
 def get_data_distribution(
     y,
     num_classes=None,

--- a/mlaas_data_generator/data/preprocessors/hf_text_generation.py
+++ b/mlaas_data_generator/data/preprocessors/hf_text_generation.py
@@ -130,6 +130,7 @@ def preprocess_hf_text_causal_lm_generation(
     tokenizer = AutoTokenizer.from_pretrained(hf_model_id, use_fast=True)
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
 
     resolved = resolve_generation_columns(ds_train, column_mapping=column_mapping, hf_task="causal_lm_generation")
     prompt_col, target_col = resolved["source"], resolved["target"]
@@ -227,6 +228,8 @@ def preprocess_hf_text_causal_lm_generation(
         "source_max_length": src_max,
         "target_max_length": tgt_max,
         "dynamic_padding": bool(dynamic_padding),
+        "pad_token_id": int(tokenizer.pad_token_id),
+        "padding_side": str(getattr(tokenizer, "padding_side", "right")),
     })
     return (X_train, y_train), (X_test, y_test), meta2
 
@@ -252,6 +255,7 @@ def preprocess_hf_text_seq2seq_generation(
     tokenizer = AutoTokenizer.from_pretrained(hf_model_id, use_fast=True)
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
 
     resolved = resolve_generation_columns(ds_train, column_mapping=column_mapping, hf_task="seq2seq_generation")
     source_col, target_col = resolved["source"], resolved["target"]

--- a/mlaas_data_generator/federated/orchestrator.py
+++ b/mlaas_data_generator/federated/orchestrator.py
@@ -9,7 +9,7 @@ from numbers import Number
 from ..config import CONFIG
 from ..data.master_loader import load_dataset
 from ..data.splitters import split_data
-from ..data.distributions import get_data_distribution, get_mlm_masked_token_stats
+from ..data.distributions import get_data_distribution, get_mlm_masked_token_stats, get_token_label_stats
 from ..storage.writer import make_writer
 from .strategies.factory import make_task_strategy
 from .strategies.base import canonical_task_family, canonical_label_format, canonical_metric_names, normalize_hf_task, metric_availability
@@ -462,12 +462,20 @@ class FederatedDataGenerator:
         print("Client data distributions before training:")
         client_distributions = {}
         is_fill_mask = self.task_family == "fill_mask"
-        ignore_index = int(self.meta.get("label_pad_value", -100))
+        is_generation = self.task_family == "generation"
+        ignore_index = int(self.meta.get("label_pad_value", self.meta.get("ignore_index", -100)))
+        pad_token_id = self.meta.get("pad_token_id")
         for client_id, data in clients.items():
             if is_fill_mask:
                 dist = get_mlm_masked_token_stats(
                     data["y"],
                     ignore_index=ignore_index,
+                )
+            elif is_generation:
+                dist = get_token_label_stats(
+                    data["y"],
+                    ignore_index=ignore_index,
+                    pad_token_id=pad_token_id,
                 )
             else:
                 dist = get_data_distribution(

--- a/mlaas_data_generator/models/adapters/hf_cache.py
+++ b/mlaas_data_generator/models/adapters/hf_cache.py
@@ -29,6 +29,9 @@ def get_cached_tokenizer(*, hf_model_id, task, device, transformers_module):
 
     if getattr(tok, "pad_token_id", None) is None and getattr(tok, "eos_token_id", None) is not None:
         tok.pad_token = tok.eos_token
+    task_name = str(task or "").strip().lower()
+    if task_name == "causal_lm_generation":
+        tok.padding_side = "left"
 
     load_s = float(time.time() - t0)
     with _CACHE_LOCK:

--- a/mlaas_data_generator/test/test_distribution_summaries.py
+++ b/mlaas_data_generator/test/test_distribution_summaries.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from mlaas_data_generator.data.distributions import get_token_label_stats
+
+
+def test_get_token_label_stats_ignores_ignore_and_pad_tokens():
+    y = np.asarray([
+        [-100, 11, 11, 0],
+        [-100, 13, 0, 13],
+    ])
+
+    stats = get_token_label_stats(y, ignore_index=-100, pad_token_id=0)
+
+    assert stats["total_tokens"] == 8
+    assert stats["supervised_tokens"] == 4
+    assert stats["unique_supervised_token_ids"] == 2
+    assert stats["top_supervised_token_ids"] == {13: 2, 11: 2} or stats["top_supervised_token_ids"] == {11: 2, 13: 2}
+    assert stats["supervised_ratio"] == 0.5

--- a/mlaas_data_generator/test/test_hf_generation_preprocessors.py
+++ b/mlaas_data_generator/test/test_hf_generation_preprocessors.py
@@ -20,6 +20,7 @@ class FakeTokenizer:
     pad_token_id = 0
     eos_token_id = 2
     pad_token = "<pad>"
+    padding_side = "right"
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
@@ -204,3 +205,20 @@ def test_seq2seq_generation_preprocessor_raises_without_plausible_target():
             hf_model_id="dummy/model",
             dynamic_padding=True,
         )
+
+
+def test_causal_lm_generation_preprocessor_sets_left_padding_and_meta():
+    _install_fake_transformers()
+    train_rows = [{"text": "left pad me"}]
+    test_rows = [{"text": "and me too"}]
+
+    _, _, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "causal_lm_generation", "modality": "text", "max_length": 8, "hf_id": "dummy"},
+        hf_model_id="dummy/model",
+        dynamic_padding=True,
+    )
+
+    assert meta["padding_side"] == "left"
+    assert meta["pad_token_id"] == 0


### PR DESCRIPTION
### Motivation
- Fix incorrect client distribution printing for HF generation runs which were being summarized as a 1-class histogram instead of token-level stats. 
- Eliminate the transformers warning for decoder-only models caused by right-padding by ensuring tokenizers use left padding for generation tasks.

### Description
- Add a token-oriented summary helper `get_token_label_stats` to report supervised token counts and top token ids for generation tasks. 
- Use `get_token_label_stats` in the orchestrator for `generation` task family while preserving existing MLM and classification paths. 
- Force `tokenizer.padding_side = "left"` for causal/seq2seq generation in preprocessing and when loading cached tokenizers, and record `pad_token_id` / `padding_side` in dataset metadata. 
- Add regression tests: one to validate token-label distribution summaries and one to assert generation preprocessor sets `padding_side`/`pad_token_id` in metadata.

### Testing
- Installed test deps with `python -m pip install numpy pytest` which completed successfully. 
- Ran targeted tests with `PYTHONPATH=. pytest -q mlaas_data_generator/test/test_hf_generation_preprocessors.py mlaas_data_generator/test/test_distribution_summaries.py`, and all tests passed (`8 passed`). 
- Verified code compiles with `python -m compileall mlaas_data_generator` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf83eaf6ac8330a9b3b23b0c8a1f60)