### PR TITLE
Use cross-entropy loss as primary metric for causal LM (loss → perplexity), update metadata and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Use `task_tag` in manifest rows / `dataset_args` to select canonical decoding me
 
 - `summarization`: `rouge1`, `rouge2`, `rougeL`
 - `translation`: `sacrebleu`
-- `language-modeling`: `perplexity` (from eval loss when labels are available)
+- `language-modeling`: `loss`, `perplexity` (with cross-entropy loss as the primary metric when labels are available)
 
 ### Required HF columns for generation rows
 
@@ -339,7 +339,9 @@ Paired integrity checks enforce image/text alignment per split. With `drop`, row
 ### Metric availability rules
 
 - **Train**: `loss`, `perplexity` (when labels are present)
-- **Eval / inference**: decoding metric(s) by `task_tag`; optional `perplexity` when labels are available
+- **Eval / inference**:
+  - `causal_lm_generation`: `loss`, `perplexity`
+  - other generation tasks: decoding metric(s) by `task_tag`; optional `perplexity` when labels are available
 
 `metric_primary_name` / `metric_secondary_name` in run metadata are selected from the canonical metric set for the configured generation subtype.
 

--- a/mlaas_data_generator/federated/orchestrator.py
+++ b/mlaas_data_generator/federated/orchestrator.py
@@ -77,17 +77,6 @@ class FederatedDataGenerator:
         if requested_task != meta_task:
             print(f"Warning: overriding dataset task type '{meta_task}' with requested '{self.task_type}'.")
 
-        # metric keys
-        if self.task_type == "clustering":
-            self.metric_key = "silhouette"
-            self.metric_label = "Silhouette"
-        elif self.task_type == "classification":
-            self.metric_key = "accuracy"
-            self.metric_label = "Accuracy"
-        else:
-            self.metric_key = "rmse"
-            self.metric_label = "RMSE"
-
         self.target_scaler = meta.get("target_scaler")
         self.save_weights = bool(self.config.get("save_weights", True))
         self.distribution_bins = int(self.config.get("distribution_bins", 10) or 10)
@@ -137,6 +126,20 @@ class FederatedDataGenerator:
             self.dataset_args.get("hf_task") or self.config.get("hf_task") or self.meta.get("hf_task")
         )
         self.task_family = canonical_task_family(self.task_type, self.hf_task)
+
+        # metric keys
+        if self.task_type == "clustering":
+            self.metric_key = "silhouette"
+            self.metric_label = "Silhouette"
+        elif self.task_family == "generation" and self.hf_task == "causal_lm_generation":
+            self.metric_key = "loss"
+            self.metric_label = "Loss"
+        elif self.task_type == "classification":
+            self.metric_key = "accuracy"
+            self.metric_label = "Accuracy"
+        else:
+            self.metric_key = "rmse"
+            self.metric_label = "RMSE"
 
         # strategy encapsulates build/train/eval details
         self.strategy = make_task_strategy(
@@ -197,9 +200,14 @@ class FederatedDataGenerator:
         task_family = canonical_task_family(self.task_type, hf_task)
         label_format = infer_label_format(self.meta, task_type=self.task_type) or canonical_label_format(task_family)
         task_tag = str(self.config.get("task_tag") or self.config.get("dataset_args", {}).get("task_tag") or "").strip().lower() or None
-        metric_primary_name, metric_secondary_name = canonical_metric_names(task_family, self.metric_key)
+        metric_primary_name, metric_secondary_name = canonical_metric_names(
+            task_family,
+            self.metric_key,
+            hf_task=hf_task,
+            task_tag=task_tag,
+        )
         has_labels = self.y_test is not None
-        availability = metric_availability(task_family, task_tag=task_tag, has_labels=has_labels)
+        availability = metric_availability(task_family, task_tag=task_tag, has_labels=has_labels, hf_task=hf_task)
         if task_family == "generation":
             eval_metrics = availability.get("eval", tuple())
             if eval_metrics:

--- a/mlaas_data_generator/federated/strategies/base.py
+++ b/mlaas_data_generator/federated/strategies/base.py
@@ -83,7 +83,7 @@ def canonical_label_format(task_family: str) -> str:
     return mapping.get(task_family, "unknown")
 
 
-def canonical_metric_names(task_family: str, metric_key: str) -> tuple[str, str | None]:
+def canonical_metric_names(task_family: str, metric_key: str, *, hf_task: str | None = None, task_tag: str | None = None) -> tuple[str, str | None]:
     if task_family == "classification":
         return ("accuracy", "f1")
     if task_family == "token_classification":
@@ -93,6 +93,12 @@ def canonical_metric_names(task_family: str, metric_key: str) -> tuple[str, str 
     if task_family == "regression":
         return ("rmse", "mae")
     if task_family == "generation":
+        hf = normalize_hf_task(hf_task)
+        tag = (task_tag or "").strip().lower().replace("-", "_")
+        if hf == "causal_lm_generation":
+            return ("loss", "perplexity")
+        if hf == "seq2seq_generation" and tag in {"", "language_modeling", "language-modeling"}:
+            return ("loss", "perplexity")
         return ("perplexity", None)
     if task_family == "clustering":
         return ("silhouette", None)
@@ -107,8 +113,12 @@ def canonical_metric_names(task_family: str, metric_key: str) -> tuple[str, str 
     return ((metric_key or "metric").lower(), None)
 
 
-def canonical_generation_metrics(task_tag: str | None, has_labels: bool) -> tuple[str, ...]:
+def canonical_generation_metrics(task_tag: str | None, has_labels: bool, *, hf_task: str | None = None) -> tuple[str, ...]:
     """Decode-centric metric set for generation by subtype."""
+    hf = normalize_hf_task(hf_task)
+    if hf == "causal_lm_generation":
+        return ("loss", "perplexity") if has_labels else tuple()
+
     tag = (task_tag or "").strip().lower().replace("-", "_")
     if tag == "summarization":
         base = ("rouge1", "rouge2", "rougeL")
@@ -124,12 +134,12 @@ def canonical_generation_metrics(task_tag: str | None, has_labels: bool) -> tupl
     return base
 
 
-def metric_availability(task_family: str, task_tag: str | None = None, has_labels: bool = True) -> dict[str, tuple[str, ...]]:
+def metric_availability(task_family: str, task_tag: str | None = None, has_labels: bool = True, *, hf_task: str | None = None) -> dict[str, tuple[str, ...]]:
     """Return canonical train/eval metric availability by task family."""
     if task_family == "generation":
         return {
             "train": ("loss", "perplexity") if has_labels else tuple(),
-            "eval": canonical_generation_metrics(task_tag=task_tag, has_labels=has_labels),
+            "eval": canonical_generation_metrics(task_tag=task_tag, has_labels=has_labels, hf_task=hf_task),
         }
 
     if task_family == "retrieval":

--- a/mlaas_data_generator/federated/strategies/hf_strategy.py
+++ b/mlaas_data_generator/federated/strategies/hf_strategy.py
@@ -35,6 +35,9 @@ class HFStrategy(TaskStrategy):
         if primary_metric_value != primary_metric_value:
             return np.nan
 
+        if self.hf_task in ("causal_lm_generation", "causal-lm", "language-modeling", "language_modeling"):
+            return metric_score_value("regression", float(primary_metric_value))
+
         # token classification primary is typically F1 already in [0,1]
         if self.hf_task in ("token_classification", "token-cls", "ner"):
             return float(primary_metric_value)

--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -868,19 +868,25 @@ class CausalLMGenerationSpec(HFTaskSpec):
         return generated[:, in_len:]
 
     def metrics(self, y_true, y_pred, y_extra=None):
-        y_true = np.asarray(y_true)
-        y_pred = np.asarray(y_pred)
-        if y_true.size == 0 or y_pred.size == 0:
-            return {"primary": np.nan, "secondary": np.nan, "named_metrics": {"perplexity": np.nan}}
-        common = min(y_true.shape[-1], y_pred.shape[-1])
-        yt = y_true[..., :common]
-        yp = y_pred[..., :common]
-        tok_acc = float((yt == yp).mean())
         loss_mean = np.nan
         if isinstance(y_extra, dict):
             loss_mean = float(y_extra.get("loss_mean", np.nan))
         ppl = float(np.exp(np.clip(loss_mean, a_min=-50.0, a_max=50.0))) if loss_mean == loss_mean else np.nan
-        return {"primary": ppl, "secondary": tok_acc, "named_metrics": {"perplexity": ppl, "token_accuracy": tok_acc}}
+        token_accuracy = np.nan
+
+        y_true = np.asarray(y_true)
+        y_pred = np.asarray(y_pred)
+        if y_true.size != 0 and y_pred.size != 0:
+            common = min(y_true.shape[-1], y_pred.shape[-1])
+            yt = y_true[..., :common]
+            yp = y_pred[..., :common]
+            token_accuracy = float((yt == yp).mean())
+
+        return {
+            "primary": loss_mean,
+            "secondary": ppl,
+            "named_metrics": {"cross_entropy_loss": loss_mean, "perplexity": ppl, "token_accuracy": token_accuracy},
+        }
 
 
 class Seq2SeqGenerationSpec(HFTaskSpec):

--- a/mlaas_data_generator/test/test_generation_metrics_and_manifest.py
+++ b/mlaas_data_generator/test/test_generation_metrics_and_manifest.py
@@ -1,8 +1,10 @@
+import numpy as np
 import pandas as pd
 
 from mlaas_data_generator.cli.manifest.hf_manifest_builder import MANIFEST_COLUMNS, build_hf_manifest
 from mlaas_data_generator.cli.run_manifest import _build_dataset_args, _resolve_row
-from mlaas_data_generator.federated.strategies.base import canonical_generation_metrics, metric_availability
+from mlaas_data_generator.federated.strategies.base import canonical_generation_metrics, canonical_metric_names, metric_availability
+from mlaas_data_generator.models.adapters.hf_task import CausalLMGenerationSpec
 from mlaas_data_generator.registry import DATASET_REGISTRY, MODEL_REGISTRY
 
 
@@ -68,10 +70,17 @@ def test_manifest_builder_uses_flat_registries_for_generation_rows():
 
 
 def test_generation_metric_availability_by_subtype():
+    assert canonical_generation_metrics(None, has_labels=True, hf_task="causal_lm_generation") == ("loss", "perplexity")
     assert canonical_generation_metrics("summarization", has_labels=True) == ("rouge1", "rouge2", "rougeL", "perplexity")
     assert canonical_generation_metrics("translation", has_labels=True) == ("sacrebleu", "perplexity")
     assert canonical_generation_metrics("translation", has_labels=False) == ("sacrebleu",)
     assert canonical_generation_metrics("captioning", has_labels=True) == ("cider", "bleu", "perplexity")
+
+    assert canonical_metric_names("generation", "loss", hf_task="causal_lm_generation") == ("loss", "perplexity")
+
+    causal_avail = metric_availability("generation", has_labels=True, hf_task="causal_lm_generation")
+    assert causal_avail["train"] == ("loss", "perplexity")
+    assert causal_avail["eval"] == ("loss", "perplexity")
 
     avail = metric_availability("generation", task_tag="summarization", has_labels=True)
     assert avail["train"] == ("loss", "perplexity")
@@ -113,3 +122,18 @@ def test_retrieval_and_vqa_metric_availability():
 
     vqa = metric_availability("vqa", has_labels=True)
     assert vqa["eval"] == ("exact_match",)
+
+
+def test_causal_lm_metrics_report_loss_as_primary_and_perplexity_as_secondary():
+    spec = CausalLMGenerationSpec()
+    out = spec.metrics(
+        np.asarray([[1, 2, 3]]),
+        np.asarray([[1, 4, 3]]),
+        y_extra={"loss_mean": 0.5},
+    )
+
+    assert np.isclose(out["primary"], 0.5)
+    assert np.isclose(out["secondary"], np.exp(0.5))
+    assert np.isclose(out["named_metrics"]["cross_entropy_loss"], 0.5)
+    assert np.isclose(out["named_metrics"]["perplexity"], np.exp(0.5))
+    assert np.isclose(out["named_metrics"]["token_accuracy"], 2 / 3)


### PR DESCRIPTION
### Motivation
- Causal language modeling runs should use cross-entropy loss as the primary quality metric with perplexity as a derived metric to match industry/paper conventions and ensure dataset comparability.
- The repository previously treated many HF generation tasks like classification (reporting accuracy/token-match as primary), which makes dataset columns inconsistent across task families.
- Unifying metric semantics for `causal_lm_generation` protects explainability, scoring, and selection logic that relies on canonical metric names and availability.

### Description
- Change `CausalLMGenerationSpec.metrics` to report `primary = loss_mean`, `secondary = perplexity`, and include `cross_entropy_loss`, `perplexity`, and `token_accuracy` in `named_metrics`. (file: `mlaas_data_generator/models/adapters/hf_task.py`).
- Extend canonical metric metadata APIs to accept `hf_task`/`task_tag` and return `loss`/`perplexity` for `causal_lm_generation` (and certain language-modeling `seq2seq` cases), and adjust generation metric availability accordingly. (file: `mlaas_data_generator/federated/strategies/base.py`).
- Update orchestration and scoring so `causal_lm_generation` runs use `loss` as the run `metric_key` and are normalized via the regression-style path (`metric_score_value`). (files: `mlaas_data_generator/federated/orchestrator.py`, `mlaas_data_generator/federated/strategies/hf_strategy.py`).
- Refresh documentation in `README.md` to state that language-modeling/causal LM uses `loss` (primary) and `perplexity` (secondary), and add unit tests exercising canonical generation metric availability and the causal-LM metrics contract. (file: `mlaas_data_generator/test/test_generation_metrics_and_manifest.py`).

### Testing
- Ran `python -m compileall mlaas_data_generator`, which completed successfully. 
- Ran `pytest -q mlaas_data_generator/test/test_generation_metrics_and_manifest.py`, but test collection failed in this environment with `ModuleNotFoundError: No module named 'numpy'`, so the new tests could not be executed here. 
- Added unit test coverage for canonical generation metrics and for verifying `CausalLMGenerationSpec.metrics` returns `loss` as primary and `perplexity` as secondary; these tests should pass when run in an environment with the test dependencies (`numpy`, etc.) installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf86d65ae4833088ddfa534134445c)