### PR TITLE
Fix HF inference generation metrics and causal-LM prompt trimming

### DIFF
--- a/mlaas_data_generator/models/adapters/hf_core.py
+++ b/mlaas_data_generator/models/adapters/hf_core.py
@@ -518,6 +518,24 @@ class HFCore:
                 )
 
                 last_extra = dict(extra or {})
+                teacher_forced = None
+                if bool(inference_only) and bool(getattr(self.task_spec, "supports_generation", False)) and yb is not None:
+                    teacher_enc, teacher_labels_t, teacher_extra = self.task_spec.encode_batch(
+                        self.tokenizer,
+                        xb,
+                        yb,
+                        self.max_length,
+                        torch,
+                        self.device,
+                        ignore_index=self.label_pad_value,
+                        inference_only=False,
+                    )
+                    teacher_forced = (teacher_enc, teacher_labels_t, dict(teacher_extra or {}))
+                    if teacher_labels_t is not None:
+                        labels_all.append(teacher_labels_t.detach().cpu().numpy())
+                        labels_recorded = True
+                        supervised_token_count = _count_supervised_tokens(teacher_labels_t, self.label_pad_value)
+                        eval_supervised_token_count += supervised_token_count
 
                 if bool(inference_only) and bool(getattr(self.task_spec, "supports_generation", False)):
                     if not first_batch_logged:
@@ -532,6 +550,37 @@ class HFCore:
                     if not first_batch_logged:
                         print("[HFCore.eval] first batch forward ends")
                     preds_all.append(pred_t.detach().cpu().numpy())
+
+                    if teacher_forced is not None:
+                        teacher_enc, teacher_labels_t, teacher_extra = teacher_forced
+                        teacher_inputs = self.task_spec.build_forward_inputs(
+                            teacher_enc,
+                            labels_t=teacher_labels_t,
+                            inference_only=False,
+                        )
+                        outputs = self.model(**teacher_inputs)
+                        logits = outputs.logits
+                        stat = self.task_spec.batch_metric_statistics(torch, logits, teacher_labels_t, teacher_extra)
+                        if stat:
+                            for k, v in stat.items():
+                                stats_accum[k] = float(stats_accum.get(k, 0.0)) + float(v)
+
+                        stat_out = self.task_spec.batch_metric_statistics_from_outputs(torch, outputs, teacher_labels_t, teacher_extra)
+                        if stat_out:
+                            for k, v in stat_out.items():
+                                stats_accum[k] = float(stats_accum.get(k, 0.0)) + float(v)
+
+                        loss = self.task_spec.extract_loss(torch, outputs, logits, teacher_labels_t, teacher_extra)
+                        if loss is not None:
+                            if teacher_labels_t.ndim >= 2:
+                                loss_denominator_count = supervised_token_count
+                            elif isinstance(xb, dict):
+                                loss_denominator_count = len(next(iter(xb.values())))
+                            else:
+                                loss_denominator_count = len(xb)
+
+                            total_loss += float(loss.detach().cpu().item()) * float(max(1, loss_denominator_count))
+                            eval_loss_denominator_count += int(max(1, loss_denominator_count))
                 else:
                     model_inputs = self.task_spec.build_forward_inputs(enc, labels_t=labels_t, inference_only=bool(inference_only))
                     if not first_batch_logged:

--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -848,14 +848,43 @@ class CausalLMGenerationSpec(HFTaskSpec):
     def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
         if isinstance(xb, dict):
             batch = {k: v for k, v in xb.items() if k in {"input_ids", "attention_mask", "token_type_ids"}}
-            if inference_only and "input_ids" in batch and "attention_mask" in batch:
+            labels_np = None if yb is None else np.asarray(yb)
+            if inference_only and labels_np is not None and "input_ids" in batch and "attention_mask" in batch:
+                input_ids = np.asarray(batch["input_ids"])
+                attention_mask = np.asarray(batch["attention_mask"])
+                if labels_np.shape == input_ids.shape:
+                    prompt_only_ids = []
+                    prompt_only_mask = []
+                    for row_ids, row_mask, row_labels in zip(input_ids, attention_mask, labels_np):
+                        active = np.asarray(row_mask).astype(bool)
+                        prompt_positions = active & (np.asarray(row_labels) == int(ignore_index))
+                        if np.any(prompt_positions):
+                            trimmed_ids = np.asarray(row_ids)[prompt_positions]
+                            trimmed_mask = np.ones(trimmed_ids.shape[0], dtype=np.asarray(row_mask).dtype)
+                        else:
+                            valid_ids = np.asarray(row_ids)[active]
+                            trimmed_ids = valid_ids[:-1] if valid_ids.shape[0] > 1 else valid_ids
+                            trimmed_mask = np.ones(trimmed_ids.shape[0], dtype=np.asarray(row_mask).dtype)
+                        prompt_only_ids.append(trimmed_ids.tolist())
+                        prompt_only_mask.append(trimmed_mask.tolist())
+                    max_prompt_len = max((len(row) for row in prompt_only_ids), default=0)
+                    pad_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+                    if pad_id is None:
+                        pad_id = 0
+                    padded_ids = []
+                    padded_mask = []
+                    for row_ids, row_mask in zip(prompt_only_ids, prompt_only_mask):
+                        pad_len = max_prompt_len - len(row_ids)
+                        padded_ids.append(([int(pad_id)] * pad_len) + list(row_ids))
+                        padded_mask.append(([0] * pad_len) + list(row_mask))
+                    batch["input_ids"] = np.asarray(padded_ids, dtype=input_ids.dtype)
+                    batch["attention_mask"] = np.asarray(padded_mask, dtype=attention_mask.dtype)
                 batch["input_ids"], batch["attention_mask"] = self._left_pad_batch(
                     tokenizer,
                     batch["input_ids"],
                     batch["attention_mask"],
                 )
             enc = {k: torch.tensor(v, dtype=torch.long, device=device) for k, v in batch.items()}
-            labels_t = None if yb is None else torch.tensor(yb, dtype=torch.long, device=device)
             labels_t = None if yb is None else torch.tensor(yb, dtype=torch.long, device=device)
             return enc, labels_t, {"ignore_index": int(ignore_index)}
 

--- a/mlaas_data_generator/test/test_hf_inference_generation_metrics.py
+++ b/mlaas_data_generator/test/test_hf_inference_generation_metrics.py
@@ -1,0 +1,175 @@
+import contextlib
+import numpy as np
+
+from mlaas_data_generator.models.adapters.hf_core import HFCore
+from mlaas_data_generator.models.adapters.hf_task import CausalLMGenerationSpec
+
+
+class FakeTensor:
+    def __init__(self, value):
+        self.value = np.asarray(value)
+        self.ndim = self.value.ndim
+        self.shape = self.value.shape
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return np.asarray(self.value)
+
+    def item(self):
+        return self.value.item()
+
+    def sum(self):
+        return FakeTensor(np.asarray(self.value.sum()))
+
+    def __ne__(self, other):
+        return FakeTensor(self.value != other)
+
+
+class FakeTorch:
+    long = "long"
+
+    @staticmethod
+    def tensor(value, dtype=None, device=None):
+        return FakeTensor(value)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def no_grad():
+        yield
+
+
+class DummyTokenizer:
+    pad_token_id = 0
+    eos_token_id = 99
+
+
+class DummyGenerationModel:
+    def __init__(self):
+        self.forward_calls = 0
+
+    def eval(self):
+        return self
+
+    def generate(self, **kwargs):
+        batch = kwargs["input_ids"].numpy()
+        generated = []
+        for row in batch:
+            prompt_tokens = [tok for tok in row.tolist() if tok != 0]
+            generated.append(prompt_tokens + [7, 8])
+        max_len = max(len(row) for row in generated)
+        padded = [row + [0] * (max_len - len(row)) for row in generated]
+        return FakeTensor(np.asarray(padded, dtype=np.int64))
+
+    def __call__(self, **kwargs):
+        self.forward_calls += 1
+        labels = kwargs["labels"].numpy()
+        logits = np.zeros((labels.shape[0], labels.shape[1], 4), dtype=np.float32)
+        return type("Out", (), {"logits": FakeTensor(logits), "loss": FakeTensor(np.asarray(0.5, dtype=np.float32))})
+
+
+class DummyGenerationSpec:
+    name = "seq2seq_generation"
+    supports_generation = True
+
+    def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
+        enc = {
+            "input_ids": torch.tensor(xb["input_ids"], dtype=torch.long, device=device),
+            "attention_mask": torch.tensor(xb["attention_mask"], dtype=torch.long, device=device),
+        }
+        labels = None
+        if yb is not None and not inference_only:
+            labels = torch.tensor(yb, dtype=torch.long, device=device)
+        return enc, labels, {"ignore_index": int(ignore_index)}
+
+    def build_forward_inputs(self, enc, labels_t=None, inference_only=False):
+        out = dict(enc)
+        if labels_t is not None and not inference_only:
+            out["labels"] = labels_t
+        return out
+
+    def generate_predictions(self, model, enc, tokenizer, torch, generation_config):
+        generated = model.generate(**enc, **generation_config)
+        in_len = enc["input_ids"].shape[1]
+        return FakeTensor(generated.numpy()[:, in_len:])
+
+    def extract_loss(self, torch, outputs, logits, labels_t, extra):
+        return outputs.loss
+
+    def batch_metric_statistics(self, torch, logits, labels_t, extra):
+        return None
+
+    def batch_metric_statistics_from_outputs(self, torch, outputs, labels_t, extra):
+        return None
+
+    def metrics_from_statistics(self, stats):
+        return None
+
+    def metrics(self, y_true, y_pred, y_extra=None):
+        common = min(y_true.shape[-1], y_pred.shape[-1])
+        score = float((y_true[:, :common] == y_pred[:, :common]).mean())
+        return {"primary": score, "secondary": 0.25, "named_metrics": {"token_accuracy": score}}
+
+
+def test_causal_lm_inference_only_strips_supervised_suffix_from_prompt_tokens():
+    spec = CausalLMGenerationSpec()
+    fake_torch = FakeTorch()
+    xb = {
+        "input_ids": np.asarray([[11, 12, 21, 22, 99]], dtype=np.int64),
+        "attention_mask": np.asarray([[1, 1, 1, 1, 1]], dtype=np.int64),
+    }
+    yb = np.asarray([[-100, -100, 21, 22, 99]], dtype=np.int64)
+
+    enc, labels_t, extra = spec.encode_batch(
+        DummyTokenizer(),
+        xb,
+        yb,
+        max_length=5,
+        torch=fake_torch,
+        device="cpu",
+        inference_only=True,
+    )
+
+    assert enc["input_ids"].numpy().tolist() == [[11, 12]]
+    assert enc["attention_mask"].numpy().tolist() == [[1, 1]]
+    assert labels_t.numpy().tolist() == yb.tolist()
+    assert extra["ignore_index"] == -100
+
+
+def test_hfcore_eval_inference_only_generation_uses_teacher_forced_labels_for_metrics_and_loss():
+    core = HFCore.__new__(HFCore)
+    core.torch = FakeTorch()
+    core.task_spec = DummyGenerationSpec()
+    core.tokenizer = DummyTokenizer()
+    core.model = DummyGenerationModel()
+    core.generation_config = {}
+    core.batch_size = 2
+    core.device = "cpu"
+    core.label_pad_value = -100
+    core.max_length = 4
+    core.model_id = "dummy"
+    core.weight_format = None
+    core.task_tag = None
+    core.tokenizer_load_s = 0.0
+    core.model_load_s = 0.0
+    core.tokenizer_cache_hit = True
+    core.model_cache_hit = True
+
+    xs = {
+        "input_ids": np.asarray([[5, 6], [7, 8]], dtype=np.int64),
+        "attention_mask": np.asarray([[1, 1], [1, 1]], dtype=np.int64),
+    }
+    ys = np.asarray([[7, 8], [7, 8]], dtype=np.int64)
+
+    loss, primary, secondary, qos = core.eval(xs, ys, inference_only=True)
+
+    assert np.isclose(loss, 0.5)
+    assert np.isclose(primary, 1.0)
+    assert np.isclose(secondary, 0.25)
+    assert qos["eval_supervised_token_count"] == 4
+    assert qos["tokens_total"] == 4
+    assert core.model.forward_calls == 1


### PR DESCRIPTION
### Motivation
- Inference-only generation runs skipped label-aware evaluation, so loss/metrics and supervised token counts were not accumulated and could produce `nan` scores despite clients participating.
- Causal-LM dict-based inputs could include supervised suffix tokens as part of the prompt during inference, effectively leaking targets into generation and bypassing intended prompt caps.
- Regression coverage for both behaviors was needed so inference loops reliably return metrics when labels are present.

### Description
- Restore a teacher-forced evaluation pass inside `HFCore.eval` when `inference_only=True` and labels are available so loss, per-token counts (`eval_supervised_token_count` / `tokens_total`), and batch metric statistics are computed and accumulated for generation tasks. 
- Trim dict-based causal-LM dict inputs to the prompt-only prefix in `CausalLMGenerationSpec.encode_batch` by using the `ignore_index` label mask and left-padding the prompt, preventing supervised suffix leakage into generation. 
- Populate `stats_accum` and `labels_all` during the teacher-forced pass so `metrics_from_statistics` and downstream aggregations can derive primary/secondary metrics.
- Add a new test file `mlaas_data_generator/test/test_hf_inference_generation_metrics.py` with two tests: one validating causal-LM prompt trimming and another validating that inference-only generation uses teacher-forced labels for loss/metric computation.

### Testing
- Ran `python -m py_compile` on `mlaas_data_generator/models/adapters/hf_core.py`, `mlaas_data_generator/models/adapters/hf_task.py`, and the new test file which succeeded without syntax errors. 
- Attempted to run `pytest` for the new test which could not be executed in this environment due to missing runtime dependency `numpy` (test collection failed with `ModuleNotFoundError: No module named 'numpy'`). 
- The new unit tests are present and exercise the changed paths and should pass in CI or a dev environment with `numpy` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69bfa02811d883309a3346b54ef55606)