### PR TITLE
Enforce left-padding for causal LM batches and prefer stricter sample_size in splitter

### DIFF
--- a/mlaas_data_generator/data/splitters.py
+++ b/mlaas_data_generator/data/splitters.py
@@ -170,8 +170,10 @@ def _shrink_dataset(x, y, sample_size=None, sample_frac=None, rng=None):
     n = _num_samples(x)
     if sample_size is None and sample_frac is None:
         return x, y
+    requested_size = None if sample_size is None else int(sample_size)
     if sample_frac is not None:
-        sample_size = int(round(n * float(sample_frac)))
+        frac_size = int(round(n * float(sample_frac)))
+        sample_size = frac_size if requested_size is None else min(requested_size, frac_size)
     sample_size = max(0, min(n, int(sample_size)))
     idx = seed.choice(n, size=sample_size, replace=False)
 

--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -846,6 +846,9 @@ class CausalLMGenerationSpec(HFTaskSpec):
         return model
 
     def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):
+        if getattr(tokenizer, "padding_side", None) != "left":
+            tokenizer.padding_side = "left"
+
         if isinstance(xb, dict):
             batch = {k: v for k, v in xb.items() if k in {"input_ids", "attention_mask", "token_type_ids"}}
             labels_np = None if yb is None else np.asarray(yb)
@@ -879,6 +882,7 @@ class CausalLMGenerationSpec(HFTaskSpec):
                         padded_mask.append(([0] * pad_len) + list(row_mask))
                     batch["input_ids"] = np.asarray(padded_ids, dtype=input_ids.dtype)
                     batch["attention_mask"] = np.asarray(padded_mask, dtype=attention_mask.dtype)
+            if "input_ids" in batch and "attention_mask" in batch:
                 batch["input_ids"], batch["attention_mask"] = self._left_pad_batch(
                     tokenizer,
                     batch["input_ids"],

--- a/mlaas_data_generator/test/test_hf_inference_generation_metrics.py
+++ b/mlaas_data_generator/test/test_hf_inference_generation_metrics.py
@@ -46,6 +46,7 @@ class FakeTorch:
 class DummyTokenizer:
     pad_token_id = 0
     eos_token_id = 99
+    padding_side = "right"
 
 
 class DummyGenerationModel:
@@ -173,3 +174,28 @@ def test_hfcore_eval_inference_only_generation_uses_teacher_forced_labels_for_me
     assert qos["eval_supervised_token_count"] == 4
     assert qos["tokens_total"] == 4
     assert core.model.forward_calls == 1
+
+
+def test_causal_lm_encode_batch_left_pads_dict_inputs_even_without_labels():
+    spec = CausalLMGenerationSpec()
+    fake_torch = FakeTorch()
+    tok = DummyTokenizer()
+    xb = {
+        "input_ids": np.asarray([[10, 11, 0, 0], [20, 21, 22, 0]], dtype=np.int64),
+        "attention_mask": np.asarray([[1, 1, 0, 0], [1, 1, 1, 0]], dtype=np.int64),
+    }
+
+    enc, labels_t, _ = spec.encode_batch(
+        tok,
+        xb,
+        None,
+        max_length=4,
+        torch=fake_torch,
+        device="cpu",
+        inference_only=True,
+    )
+
+    assert tok.padding_side == "left"
+    assert enc["input_ids"].numpy().tolist() == [[0, 0, 10, 11], [0, 20, 21, 22]]
+    assert enc["attention_mask"].numpy().tolist() == [[0, 0, 1, 1], [0, 1, 1, 1]]
+    assert labels_t is None

--- a/mlaas_data_generator/test/test_splitters.py
+++ b/mlaas_data_generator/test/test_splitters.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from mlaas_data_generator.data.splitters import _shrink_dataset
+
+
+def test_shrink_dataset_uses_stricter_bound_when_size_and_frac_provided():
+    x = np.arange(100)
+    y = np.arange(100)
+
+    x2, y2 = _shrink_dataset(x, y, sample_size=10, sample_frac=0.8, rng=123)
+
+    assert len(x2) == 10
+    assert len(y2) == 10


### PR DESCRIPTION
### Motivation
- Prevent runtime warnings and incorrect generation stemming from decoder-only models seeing right-padded inputs by ensuring causal-LM tokenizers and batches use left-padding. 
- Make dataset shrinking deterministic and predictable when both `sample_size` and `sample_frac` are provided by using the stricter (smaller) cap to limit run length and token volume.

### Description
- In `CausalLMGenerationSpec.encode_batch` enforce `tokenizer.padding_side = "left"` and normalize dict-backed `input_ids`/`attention_mask` to true left-padding before tensorization so generation never observes right-padded sequences. 
- Ensure existing inference-only prompt-trimming logic is preserved while still left-padding any incoming right-padded arrays prior to calling `_left_pad_batch`. 
- Update `_shrink_dataset` in `data/splitters.py` so when both `sample_size` and `sample_frac` are provided the code computes `frac_size` and uses `min(requested_size, frac_size)` (or `frac_size` if no `sample_size` was requested). 
- Add/modify tests: new `mlaas_data_generator/test/test_splitters.py` and an augmented `mlaas_data_generator/test/test_hf_inference_generation_metrics.py` to cover left-padding behavior for dict inputs and the shrink precedence change.

### Testing
- Ran `pytest -q mlaas_data_generator/test/test_hf_inference_generation_metrics.py mlaas_data_generator/test/test_splitters.py` which failed during collection with `ModuleNotFoundError: No module named 'numpy'` in this environment. 
- Unit tests for the new behaviors are included in the tree (`test_splitters.py` and the updated `test_hf_inference_generation_metrics.py`) and should pass when run in an environment with test dependencies installed (notably `numpy`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc3d41574833080f71029600555ed)