### PR TITLE
Fallback to IID for token-level labels and enforce left-padding for causal LM generation

### DIFF
--- a/mlaas_data_generator/data/splitters.py
+++ b/mlaas_data_generator/data/splitters.py
@@ -22,6 +22,19 @@ def _num_samples(x):
         return int(len(first))
     return int(len(x))
 
+
+def _is_scalar_label_vector(y):
+    """True when labels are a 1D vector of per-example scalar class ids."""
+    arr = np.asarray(y, dtype=object)
+    if arr.ndim != 1:
+        return False
+    if arr.size == 0:
+        return True
+    sample = arr[0]
+    if isinstance(sample, (list, tuple, dict, np.ndarray)):
+        return False
+    return True
+
 def _build_clients_from_indices(x, y, indices_by_client: dict):
     clients = {}
     for cid, idx in indices_by_client.items():
@@ -191,6 +204,14 @@ def split_data(x, y, num_clients, strategy = "iid", distribution_param = None, c
         x,y = _shrink_dataset(x=x, y=y, sample_frac=sample_frac, sample_size=sample_size, rng=rng)
     
     resolved = {"strategy": strategy, "distribution_param": None}
+    requires_scalar_labels = {"dirichlet", "shard", "label_per_client", "custom"}
+    if strategy in requires_scalar_labels and not _is_scalar_label_vector(y):
+        resolved["strategy"] = "iid"
+        resolved["fallback_reason"] = (
+            f"strategy='{strategy}' requires scalar class labels; "
+            "falling back to iid split for structured/token labels"
+        )
+        return _split_iid(x, y, num_clients, rng=rng), resolved
 
     if num_clients <= 0:
         raise ValueError("num_clients must be positive.")

--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -927,6 +927,8 @@ class CausalLMGenerationSpec(HFTaskSpec):
         return torch.argmax(logits, dim=-1)
 
     def generate_predictions(self, model, enc, tokenizer, torch, generation_config):
+        if getattr(tokenizer, "padding_side", None) != "left":
+            tokenizer.padding_side = "left"
         cfg = dict(generation_config)
         if cfg.get("pad_token_id") is None and tokenizer.pad_token_id is not None:
             cfg["pad_token_id"] = int(tokenizer.pad_token_id)

--- a/mlaas_data_generator/test/test_splitters.py
+++ b/mlaas_data_generator/test/test_splitters.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mlaas_data_generator.data.splitters import _shrink_dataset
+from mlaas_data_generator.data.splitters import _shrink_dataset, split_data
 
 
 def test_shrink_dataset_uses_stricter_bound_when_size_and_frac_provided():
@@ -11,3 +11,14 @@ def test_shrink_dataset_uses_stricter_bound_when_size_and_frac_provided():
 
     assert len(x2) == 10
     assert len(y2) == 10
+
+
+def test_dirichlet_falls_back_to_iid_for_token_level_labels():
+    x = np.arange(20)
+    y = np.tile(np.arange(4), (20, 1))
+
+    clients, resolved = split_data(x, y, num_clients=2, strategy="dirichlet", distribution_param=0.5, rng=123)
+
+    assert set(clients.keys()) == {"client_1", "client_2"}
+    assert resolved["strategy"] == "iid"
+    assert "fallback_reason" in resolved


### PR DESCRIPTION
### Motivation
- Token-level labels (e.g. per-token sequences used for `causal_lm_generation`) were being treated like scalar class labels by non-IID split strategies, producing massively inflated sequence/token counts and long inference loops. 
- A runtime tokenizer state drift could cause right-padding to be present at generation time, triggering the decoder-only padding warning and producing incorrect generation alignment.

### Description
- Add `_is_scalar_label_vector(y)` to detect whether `y` is a 1-D vector of scalar class ids and return `False` for token/structured labels. 
- Make `split_data(...)` fall back to IID splitting when requested strategies that require scalar class labels (`dirichlet`, `shard`, `label_per_client`, `custom`) are used with structured/token labels, and include a `fallback_reason` in the returned `resolved` metadata. 
- Enforce `tokenizer.padding_side = "left"` immediately before `model.generate(...)` in `CausalLMGenerationSpec.generate_predictions` to silence the decoder-only right-padding warning and ensure correct generation behavior. 
- Add a unit test `test_dirichlet_falls_back_to_iid_for_token_level_labels` verifying the `dirichlet`->IID fallback for token-level labels. 

### Testing
- Compiled modified modules with `python -m py_compile mlaas_data_generator/data/splitters.py mlaas_data_generator/models/adapters/hf_task.py mlaas_data_generator/test/test_splitters.py` and compilation succeeded. 
- Ran `pytest -q mlaas_data_generator/test/test_splitters.py mlaas_data_generator/test/test_hf_inference_generation_metrics.py` but test collection failed due to missing runtime dependency `numpy` in the environment (ModuleNotFoundError), so pytest did not execute the new test; collection failure is environmental and not caused by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc59bebf88330aefd16487a515299)