### PR TITLE
Force left padding for decoder-only generation in HFCore

### DIFF
--- a/mlaas_data_generator/models/adapters/hf_core.py
+++ b/mlaas_data_generator/models/adapters/hf_core.py
@@ -120,6 +120,14 @@ class HFCore:
         except Exception:
             return "cpu"
 
+    def _ensure_left_padding_for_decoder_only_generation(self):
+        if not bool(getattr(self.task_spec, "supports_generation", False)):
+            return
+        model_cfg = getattr(self.model, "config", None)
+        is_encoder_decoder = bool(getattr(model_cfg, "is_encoder_decoder", False))
+        if not is_encoder_decoder and getattr(self.tokenizer, "padding_side", None) != "left":
+            self.tokenizer.padding_side = "left"
+
     def _batch_iter(self, xs, ys):
         bs = self.batch_size
 
@@ -538,6 +546,7 @@ class HFCore:
                         eval_supervised_token_count += supervised_token_count
 
                 if bool(inference_only) and bool(getattr(self.task_spec, "supports_generation", False)):
+                    self._ensure_left_padding_for_decoder_only_generation()
                     if not first_batch_logged:
                         print("[HFCore.eval] model forward starts")
                     pred_t = self.task_spec.generate_predictions(

--- a/mlaas_data_generator/test/test_hf_inference_generation_metrics.py
+++ b/mlaas_data_generator/test/test_hf_inference_generation_metrics.py
@@ -52,6 +52,7 @@ class DummyTokenizer:
 class DummyGenerationModel:
     def __init__(self):
         self.forward_calls = 0
+        self.config = type("Cfg", (), {"is_encoder_decoder": False})()
 
     def eval(self):
         return self
@@ -174,6 +175,7 @@ def test_hfcore_eval_inference_only_generation_uses_teacher_forced_labels_for_me
     assert qos["eval_supervised_token_count"] == 4
     assert qos["tokens_total"] == 4
     assert core.model.forward_calls == 1
+    assert core.tokenizer.padding_side == "left"
 
 
 def test_causal_lm_encode_batch_left_pads_dict_inputs_even_without_labels():


### PR DESCRIPTION
### Motivation
- Prevent runtime warnings and incorrect generation behavior when a decoder-only Hugging Face model is used with a tokenizer that is right-padded by forcing left-padding for generation paths.

### Description
- Add `HFCore._ensure_left_padding_for_decoder_only_generation()` which checks `model.config.is_encoder_decoder` and sets `tokenizer.padding_side = "left"` for decoder-only generation tasks when appropriate in `mlaas_data_generator/models/adapters/hf_core.py`.
- Call the new safeguard immediately before invoking `generate_predictions` in the inference-only generation path inside `HFCore.eval`.
- Update `mlaas_data_generator/test/test_hf_inference_generation_metrics.py` to provide a decoder-only model config on the dummy model and assert that `core.tokenizer.padding_side` is set to `"left"` after `eval`.

### Testing
- Ran `pytest -q mlaas_data_generator/test/test_hf_inference_generation_metrics.py` to validate the change, but collection failed due to missing test dependency: `ModuleNotFoundError: No module named 'numpy'` in the test environment, so the test could not be executed to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc8975d3c8330b30fc776f84ea00f)