### PR TITLE
Infer and emit HF vision `input_shape` and normalize HF manifest `modality`

### DIFF
--- a/mlaas_data_generator/cli/manifest/hf_manifest_builder.py
+++ b/mlaas_data_generator/cli/manifest/hf_manifest_builder.py
@@ -242,6 +242,11 @@ def _row_from_registry(
         "audit_json_used": bool(audit_meta),
     }
     explainability = _resolve_explainability_metadata(model=model, dataset_spec=dataset_spec, run_regime=run_regime)
+    resolved_modality = str(dataset_spec.get("modality") or "").strip().lower()
+    if resolved_modality not in {"text", "image", "multimodal"} or (
+        task_spec.modality and resolved_modality != task_spec.modality
+    ):
+        resolved_modality = task_spec.modality or "text"
 
     row = {
         "external_run_id": f"hf_{task_spec.task_label}_{run_index:06d}",
@@ -278,7 +283,7 @@ def _row_from_registry(
         "model_type": model_defaults["model_type"] if run_regime == "inference_only" else (model.get("model_type") or model_defaults["model_type"]),
         "hf_task": task_spec.hf_task,
         "task_type": dataset_spec.get("task_type", task_spec.task_type),
-        "modality": dataset_spec.get("modality", "text"),
+        "modality": resolved_modality,
         "dataset_name": dataset_spec.get("dataset_name"),
         "dataset_config": dataset_spec.get("dataset_config"),
         "hf_model_id": model_id,

--- a/mlaas_data_generator/data/preprocessors/hf_image.py
+++ b/mlaas_data_generator/data/preprocessors/hf_image.py
@@ -235,8 +235,13 @@ def preprocess_hf_image(
         metric_instance_count=len(y_test),
     )
     meta = finalize_accounting(meta)
+    inferred_input_shape = ()
+    pixel_values = x_train.get("pixel_values") if isinstance(x_train, dict) else None
+    if pixel_values and len(pixel_values) > 0:
+        inferred_input_shape = tuple(getattr(pixel_values[0], "shape", ()))
     meta.update(
         {
+            "input_shape": inferred_input_shape,
             "image_column": image_column,
             "label_column": label_column,
             "boxes_column": boxes_column,

--- a/mlaas_data_generator/data/preprocessors/hf_multimodal.py
+++ b/mlaas_data_generator/data/preprocessors/hf_multimodal.py
@@ -254,8 +254,13 @@ def preprocess_hf_multimodal(
         metric_instance_count=len(y_test),
     )
     meta = finalize_accounting(meta)
+    inferred_input_shape = ()
+    pixel_values = x_train.get("pixel_values") if isinstance(x_train, dict) else None
+    if pixel_values and len(pixel_values) > 0:
+        inferred_input_shape = tuple(getattr(pixel_values[0], "shape", ()))
     meta.update(
         {
+            "input_shape": inferred_input_shape,
             "modality": "multimodal",
             "hf_task": hf_task,
             "hf_processor": hf_model_id,

--- a/mlaas_data_generator/federated/orchestrator.py
+++ b/mlaas_data_generator/federated/orchestrator.py
@@ -28,6 +28,34 @@ class _StageTimer:
         return float(time.perf_counter() - self._start)
 
 
+def _first_sample_shape(x_train):
+    """Best-effort shape inference for metadata compatibility."""
+    if isinstance(x_train, dict):
+        if "pixel_values" in x_train and len(x_train["pixel_values"]) > 0:
+            sample = x_train["pixel_values"][0]
+            return tuple(getattr(sample, "shape", ()))
+        if "input_ids" in x_train and len(x_train["input_ids"]) > 0:
+            sample = x_train["input_ids"][0]
+            seq_len = int(len(sample))
+            return (seq_len,)
+        return tuple()
+
+    if hasattr(x_train, "shape"):
+        shape = tuple(getattr(x_train, "shape", ()))
+        if len(shape) > 1:
+            return tuple(shape[1:])
+        return shape
+
+    if isinstance(x_train, (list, tuple)) and len(x_train) > 0:
+        sample = x_train[0]
+        if hasattr(sample, "shape"):
+            return tuple(getattr(sample, "shape", ()))
+        arr = np.asarray(sample)
+        return tuple(arr.shape)
+
+    return tuple()
+
+
 class FederatedDataGenerator:
     """Generate MLaaS client records using a simple federated-learning loop."""
     def __init__(
@@ -68,7 +96,11 @@ class FederatedDataGenerator:
         self._run_stage_measurements["stage_dataset_load_s"] = dataset_load_timer.elapsed_s()
         (self.x_train, self.y_train), (self.x_test, self.y_test) = train, test
         self.meta = meta
-        self.input_shape = tuple(meta["input_shape"])
+        resolved_input_shape = meta.get("input_shape")
+        if resolved_input_shape is None:
+            resolved_input_shape = _first_sample_shape(self.x_train)
+            self.meta["input_shape"] = tuple(resolved_input_shape)
+        self.input_shape = tuple(resolved_input_shape)
         self.num_classes = meta.get("num_classes")
 
         # task type resolution


### PR DESCRIPTION
### Motivation
- HF vision and multimodal runs were crashing with `KeyError: 'input_shape'` because newer HF registry manifests emit `input_schema`/task descriptors but not the legacy `input_shape` field the orchestrator expects.  
- Several HF vision runs were also labelled with incorrect `modality` (e.g. `"text"`) due to registry values not matching canonical task modality, causing downstream mismatches.  

### Description
- Added a defensive shape inference helper `_first_sample_shape` in `mlaas_data_generator/federated/orchestrator.py` and used it to populate `meta['input_shape']` when the field is missing so the orchestrator no longer raises `KeyError`.  
- Emit `input_shape` from HF vision preprocessors by deriving the encoded image tensor shape in `mlaas_data_generator/data/preprocessors/hf_image.py`.  
- Emit `input_shape` from HF multimodal preprocessors (image+text pipelines) by deriving the encoded image tensor shape in `mlaas_data_generator/data/preprocessors/hf_multimodal.py`.  
- Normalize generated HF manifest modality values in `mlaas_data_generator/cli/manifest/hf_manifest_builder.py` so that missing/invalid or conflicting modality values fall back to the canonical modality for the resolved `hf_task`.  

### Testing
- Successfully compiled the package with `python -m compileall mlaas_data_generator`.  
- Attempted targeted unit tests with `pytest -q mlaas_data_generator/test/test_hf_image_preprocessor.py mlaas_data_generator/test/test_hf_multimodal_schema.py`, but collection failed due to the test environment missing `numpy` (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccd15d7648330a1ee7ccea4849389)