### PR TITLE
Fix HF vision modality routing and route HF model families through HFStrategy

### DIFF
--- a/mlaas_data_generator/cli/manifest/hf_manifest_builder.py
+++ b/mlaas_data_generator/cli/manifest/hf_manifest_builder.py
@@ -15,25 +15,27 @@ from mlaas_data_generator.registry import DATASET_REGISTRY, MODEL_REGISTRY
 class TaskSpec:
     pipeline_tag: str
     hf_task: str
+    modality: str
     task_type: str
     task_label: str
     task_tag: str | None = None
 
 
 TASK_SPECS: dict[str, TaskSpec] = {
-    "text_classification": TaskSpec("text-classification", "sequence_classification", "classification", "textcls"),
-    "token_classification": TaskSpec("token-classification", "token_classification", "classification", "tokencls"),
-    "sentence_similarity": TaskSpec("sentence-similarity", "sentence_similarity", "classification", "pairscore"),
-    "fill_mask": TaskSpec("fill-mask", "fill_mask", "classification", "fillmask"),
-    "text_generation": TaskSpec("text-generation", "causal_lm_generation", "classification", "textgen", "language-modeling"),
-    "text2text_generation": TaskSpec("text2text-generation", "seq2seq_generation", "classification", "text2text", "summarization"),
-    "image_classification": TaskSpec("image-classification", "image_classification", "classification", "imgcls"),
-    "object_detection": TaskSpec("object-detection", "image_detection", "detection", "objdet"),
-    "image_segmentation": TaskSpec("image-segmentation", "image_segmentation", "segmentation", "imgseg"),
-    "image_captioning": TaskSpec("image-to-text", "image_captioning", "generation", "imgcap", "captioning"),
+    "text_classification": TaskSpec("text-classification", "sequence_classification", "text", "classification", "textcls"),
+    "token_classification": TaskSpec("token-classification", "token_classification", "text", "classification", "tokencls"),
+    "sentence_similarity": TaskSpec("sentence-similarity", "sentence_similarity", "text", "classification", "pairscore"),
+    "fill_mask": TaskSpec("fill-mask", "fill_mask", "text", "classification", "fillmask"),
+    "text_generation": TaskSpec("text-generation", "causal_lm_generation", "text", "classification", "textgen", "language-modeling"),
+    "text2text_generation": TaskSpec("text2text-generation", "seq2seq_generation", "text", "classification", "text2text", "summarization"),
+    "image_classification": TaskSpec("image-classification", "image_classification", "image", "classification", "imgcls"),
+    "object_detection": TaskSpec("object-detection", "image_detection", "image", "detection", "objdet"),
+    "image_segmentation": TaskSpec("image-segmentation", "image_segmentation", "image", "segmentation", "imgseg"),
+    "image_captioning": TaskSpec("image-to-text", "image_captioning", "multimodal", "generation", "imgcap", "captioning"),
     "text_image_retrieval": TaskSpec(
         "zero-shot-image-classification",
         "text_image_retrieval",
+        "multimodal",
         "retrieval",
         "imgtxtret",
         "retrieval",
@@ -41,6 +43,7 @@ TASK_SPECS: dict[str, TaskSpec] = {
     "visual_question_answering": TaskSpec(
         "visual-question-answering",
         "visual_question_answering",
+        "multimodal",
         "vqa",
         "vqa",
         "vqa",

--- a/mlaas_data_generator/federated/strategies/factory.py
+++ b/mlaas_data_generator/federated/strategies/factory.py
@@ -1,16 +1,19 @@
 from .hf_strategy import HFStrategy
 from .keras_strategy import ClassificationStrategy, RegressionStrategy
 from .clustering import ClusteringStrategy
-from .base import TaskStrategy
+from .base import TaskStrategy, canonical_task_family
 
 
 def make_task_strategy(task_type: str, meta: dict, knobs: dict, config: dict, x_test, y_test, metric_key: str, save_weights: bool) -> TaskStrategy:
+    mt = (config.get("model_type") or "").lower()
+    is_hf_model = mt in ("hf", "hf_text", "transformers", "hf_finetune", "hf_train", "transformers_finetune")
+    hf_task = (config.get("hf_task") or (config.get("dataset_args", {}) or {}).get("hf_task"))
+    task_family = canonical_task_family(task_type, hf_task)
+
+    if is_hf_model and task_family in {"classification", "detection", "segmentation", "generation", "retrieval", "vqa"}:
+        return HFStrategy(meta, knobs, config, x_test, y_test, metric_key, save_weights)
+
     if task_type == "classification":
-        mt = (config.get("model_type") or "").lower()
-        
-        if mt in ("hf", "hf_text", "transformers", "hf_finetune", "hf_train", "transformers_finetune"):
-            return HFStrategy(meta, knobs, config, x_test, y_test, metric_key, save_weights)
-        
         return ClassificationStrategy(meta, knobs, config, x_test, y_test, metric_key, save_weights)
 
     if task_type == "regression":


### PR DESCRIPTION
### Motivation
- HF image and multimodal runs were being misrouted as text runs because task specs lacked explicit `modality`, causing tokenizers to be loaded for vision models. 
- Several HF tasks (detection, segmentation, captioning/generation, retrieval, VQA) raised `Unknown task type` during strategy selection because the strategy factory only routed HF models through the HF strategy for classification.

### Description
- Added a `modality` field to the HF manifest `TaskSpec` dataclass and populated each `TASK_SPECS` entry with explicit modality values (`text`, `image`, `multimodal`).
- Updated `make_task_strategy` to import and use `canonical_task_family` and to detect HF model types via `model_type` to decide routing.
- Changed strategy selection so HF model types are handled by `HFStrategy` when the canonical task family is one of `classification`, `detection`, `segmentation`, `generation`, `retrieval`, or `vqa`, and fell back to existing `ClassificationStrategy`/`RegressionStrategy`/`ClusteringStrategy` otherwise.

### Testing
- Ran Python compilation checks with `python -m py_compile mlaas_data_generator/cli/manifest/hf_manifest_builder.py mlaas_data_generator/federated/strategies/factory.py`, which succeeded.
- Attempted to run targeted tests with `pytest -q mlaas_data_generator/test/test_generation_metrics_and_manifest.py mlaas_data_generator/test/test_hf_strategy_weighting.py`, but collection failed in this environment due to missing test dependencies (for example `numpy`) and import path issues, so pytest could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd011ef2c833093280c084540a9f2)