### PR TITLE
Skip HF tokenizer for image specs and add manifest task-type support to federated strategy

### DIFF
--- a/mlaas_data_generator/federated/strategies/base.py
+++ b/mlaas_data_generator/federated/strategies/base.py
@@ -42,6 +42,19 @@ def canonical_task_family(task_type: str | None, hf_task: str | None = None) -> 
     base = (task_type or "").strip().lower()
     hf = normalize_hf_task(hf_task)
 
+    if base in {"image_classification"}:
+        return "classification"
+    if base in {"object_detection", "image_detection", "detection"}:
+        return "detection"
+    if base in {"image_segmentation", "semantic_segmentation", "segmentation"}:
+        return "segmentation"
+    if base in {"generation", "text_generation", "text2text_generation", "image_captioning"}:
+        return "generation"
+    if base in {"retrieval", "text_image_retrieval", "image_text_retrieval"}:
+        return "retrieval"
+    if base in {"vqa", "visual_question_answering", "visual_qa"}:
+        return "vqa"
+
     if base == "clustering":
         return "clustering"
     if base == "regression":

--- a/mlaas_data_generator/models/adapters/hf_core.py
+++ b/mlaas_data_generator/models/adapters/hf_core.py
@@ -48,12 +48,18 @@ class HFCore:
         self.task_spec = task_spec or SequenceClassificationSpec()
         self.generation_config = self._resolve_generation_config(generation_config)
         self.task_tag = (task_tag or "").strip().lower().replace("-", "_") or None
-        self.tokenizer, self.tokenizer_load_s, self.tokenizer_cache_hit = get_cached_tokenizer(
-            hf_model_id=model_id,
-            task=getattr(self.task_spec, "name", None),
-            device=self.device,
-            transformers_module=transformers,
-        )
+        tokenizer_required = bool(getattr(self.task_spec, "requires_tokenizer", True))
+        if tokenizer_required:
+            self.tokenizer, self.tokenizer_load_s, self.tokenizer_cache_hit = get_cached_tokenizer(
+                hf_model_id=model_id,
+                task=getattr(self.task_spec, "name", None),
+                device=self.device,
+                transformers_module=transformers,
+            )
+        else:
+            self.tokenizer = None
+            self.tokenizer_load_s = 0.0
+            self.tokenizer_cache_hit = True
 
         self.model = None
         self.weight_format = None

--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -17,6 +17,7 @@ class HFTaskSpec:
     name = "base"
 
     requires_num_labels = True
+    requires_tokenizer = True
     supports_generation = False
 
     def build_model(self, transformers, model_id, num_labels):
@@ -378,6 +379,7 @@ class TokenClassificationSpec(HFTaskSpec):
 
 class ImageClassificationSpec(HFTaskSpec):
     name = "image_classification"
+    requires_tokenizer = False
 
     def build_model(self, transformers, model_id, num_labels):
         return transformers.AutoModelForImageClassification.from_pretrained(
@@ -434,6 +436,7 @@ class ImageClassificationSpec(HFTaskSpec):
 
 class ObjectDetectionSpec(HFTaskSpec):
     name = "image_detection"
+    requires_tokenizer = False
 
     def __init__(self, score_threshold=0.05):
         self.score_threshold = float(score_threshold)
@@ -565,6 +568,7 @@ class ObjectDetectionSpec(HFTaskSpec):
 
 class ImageSegmentationSpec(HFTaskSpec):
     name = "image_segmentation"
+    requires_tokenizer = False
 
     def build_model(self, transformers, model_id, num_labels):
         return transformers.AutoModelForSemanticSegmentation.from_pretrained(

--- a/mlaas_data_generator/test/test_generation_metrics_and_manifest.py
+++ b/mlaas_data_generator/test/test_generation_metrics_and_manifest.py
@@ -3,7 +3,12 @@ import pandas as pd
 
 from mlaas_data_generator.cli.manifest.hf_manifest_builder import MANIFEST_COLUMNS, build_hf_manifest
 from mlaas_data_generator.cli.run_manifest import _build_dataset_args, _resolve_row
-from mlaas_data_generator.federated.strategies.base import canonical_generation_metrics, canonical_metric_names, metric_availability
+from mlaas_data_generator.federated.strategies.base import (
+    canonical_generation_metrics,
+    canonical_metric_names,
+    canonical_task_family,
+    metric_availability,
+)
 from mlaas_data_generator.models.adapters.hf_task import CausalLMGenerationSpec
 from mlaas_data_generator.registry import DATASET_REGISTRY, MODEL_REGISTRY
 
@@ -122,6 +127,14 @@ def test_retrieval_and_vqa_metric_availability():
 
     vqa = metric_availability("vqa", has_labels=True)
     assert vqa["eval"] == ("exact_match",)
+
+
+def test_canonical_task_family_accepts_manifest_task_types():
+    assert canonical_task_family("detection", None) == "detection"
+    assert canonical_task_family("segmentation", None) == "segmentation"
+    assert canonical_task_family("generation", None) == "generation"
+    assert canonical_task_family("retrieval", None) == "retrieval"
+    assert canonical_task_family("image_classification", None) == "classification"
 
 
 def test_causal_lm_metrics_report_loss_as_primary_and_perplexity_as_secondary():

--- a/mlaas_data_generator/test/test_hf_image_task_specs.py
+++ b/mlaas_data_generator/test/test_hf_image_task_specs.py
@@ -41,3 +41,9 @@ def test_segmentation_metrics_from_statistics_iou_and_dice():
     )
     assert np.isclose(out["primary"], 0.5)
     assert np.isclose(out["secondary"], 2 * 30 / (40 + 50))
+
+
+def test_image_specs_do_not_require_tokenizer():
+    assert ImageClassificationSpec.requires_tokenizer is False
+    assert ObjectDetectionSpec.requires_tokenizer is False
+    assert ImageSegmentationSpec.requires_tokenizer is False


### PR DESCRIPTION
### Motivation
- Image-only HF models (e.g. ViT/MobileViT) were being routed through text/tokenizer paths and failing during `AutoTokenizer.from_pretrained(...)` instantiation.  
- Rows in manifests using direct task_type aliases such as `detection`, `segmentation`, `generation`, and `retrieval` were rejected by the federated strategy factory with `Unknown task type`.  

### Description
- Added a `requires_tokenizer` attribute to `HFTaskSpec` (default `True`) and set `requires_tokenizer = False` on image specs `ImageClassificationSpec`, `ObjectDetectionSpec`, and `ImageSegmentationSpec` so image-only tasks do not force a tokenizer.  
- Updated `HFCore` to consult `task_spec.requires_tokenizer` and only call `get_cached_tokenizer(...)` when a tokenizer is required; otherwise it leaves `self.tokenizer = None` and sets tokenizer timing/cache values accordingly.  
- Expanded `canonical_task_family(...)` in the federated strategies base to directly accept common manifest-level task aliases (`detection`, `segmentation`, `generation`, `retrieval`, `vqa`, plus several image aliases) so orchestrator/strategy selection no longer treats those as unknown.  
- Added unit tests for the new behavior: `test_image_specs_do_not_require_tokenizer` asserting the image specs do not require a tokenizer, and `test_canonical_task_family_accepts_manifest_task_types` validating manifest task-type normalization.  

### Testing
- Ran `python -m compileall` on the modified modules and tests, which succeeded.  
- Ran the targeted `pytest` invocation for the changed tests but collection failed in this environment due to an external missing dependency (`ModuleNotFoundError: No module named 'numpy'`), so full pytest execution could not complete here.  
- Static/compile checks passed and the added unit tests exercise the two failure modes described (tokenizer routing and manifest task-type mapping).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd2eaa3b88330b47a0f99881c7484)