### PR TITLE
Fix IID splitter to preserve remainder samples and add IID tests

### DIFF
--- a/mlaas_data_generator/data/splitters.py
+++ b/mlaas_data_generator/data/splitters.py
@@ -51,9 +51,9 @@ def _split_iid(x, y, num_clients, rng=None):
     seed = _seed(rng)
 
     idx = seed.permutation(n)
-    data_per_client = n // num_clients
+    splits = np.array_split(idx, num_clients)
     indices_by_client = {
-        f"client_{i+1}" : idx[i*data_per_client: (i+1)*data_per_client] for i in range(num_clients)
+        f"client_{i+1}": split for i, split in enumerate(splits)
     }
     return _build_clients_from_indices(x, y, indices_by_client)
 

--- a/mlaas_data_generator/test/test_splitters.py
+++ b/mlaas_data_generator/test/test_splitters.py
@@ -22,3 +22,40 @@ def test_dirichlet_falls_back_to_iid_for_token_level_labels():
     assert set(clients.keys()) == {"client_1", "client_2"}
     assert resolved["strategy"] == "iid"
     assert "fallback_reason" in resolved
+
+
+def test_iid_with_fewer_samples_than_clients_preserves_all_samples_without_crash():
+    x = np.arange(3)
+    y = np.arange(3)
+
+    clients, resolved = split_data(x, y, num_clients=5, strategy="iid", rng=123)
+
+    assert resolved["strategy"] == "iid"
+    assert len(clients) == 5
+    assigned = sum(len(client["x"]) for client in clients.values())
+    non_empty = sum(1 for client in clients.values() if len(client["x"]) > 0)
+    assert assigned == len(x)
+    assert non_empty >= 1
+
+
+def test_iid_with_remainder_does_not_drop_records():
+    x = np.arange(10)
+    y = np.arange(10)
+
+    clients, _ = split_data(x, y, num_clients=3, strategy="iid", rng=123)
+
+    assigned_indices = np.concatenate([client["x"] for client in clients.values()])
+    assert len(assigned_indices) == len(x)
+    assert set(assigned_indices.tolist()) == set(x.tolist())
+
+
+def test_iid_total_assigned_equals_original_sample_count():
+    x = np.arange(17)
+    y = np.arange(17)
+
+    clients, _ = split_data(x, y, num_clients=4, strategy="iid", rng=123)
+
+    total_x = sum(len(client["x"]) for client in clients.values())
+    total_y = sum(len(client["y"]) for client in clients.values())
+    assert total_x == len(x)
+    assert total_y == len(y)


### PR DESCRIPTION
### Motivation
- Ensure IID splitting assigns every sample to a client (no dropped records) and preserves remainder samples when `n % num_clients != 0`, and handle `n < num_clients` without crashing.

### Description
- Replace the floor-division slicing in `_split_iid` with a shuffle via `seed.permutation(n)` followed by `np.array_split(idx, num_clients)`, then map each split to `client_1..client_n` while keeping the output schema `{"client_i": {"x": ..., "y": ...}}`.
- Keep all existing APIs and behavior except for the more correct distribution of leftover samples to clients.
- Add tests `test_iid_with_fewer_samples_than_clients_preserves_all_samples_without_crash`, `test_iid_with_remainder_does_not_drop_records`, and `test_iid_total_assigned_equals_original_sample_count` in `mlaas_data_generator/test/test_splitters.py` to validate the new behavior.

### Testing
- Added unit tests as listed above and attempted to run them with `pytest -q mlaas_data_generator/test/test_splitters.py`.
- The test run failed to collect tests due to an environment error: `ModuleNotFoundError: No module named 'numpy'`, so automated test execution did not complete in this environment.
- The new tests are present and should pass when run in an environment with `numpy` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdc3527688330b9b5e3b97f7bf46f)