### PR TITLE
Add zero-sample guards for HF preprocessing and client training

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf.py
+++ b/mlaas_data_generator/data/preprocessors/hf.py
@@ -74,6 +74,15 @@ def _validate_hf_preprocessor_output(train, test, meta):
 
     train_count = len(next(iter(x_train.values())))
     test_count = len(next(iter(x_test.values())))
+    if train_count == 0 or test_count == 0:
+        train_split = meta.get("train_split", "train")
+        test_split = meta.get("test_split", "test")
+        raise ValueError(
+            f"HF preprocessor output validation failed for task '{hf_task}': "
+            f"zero samples detected "
+            f"(split='{train_split}', count={train_count}; split='{test_split}', count={test_count}). "
+            f"Expected keys={sorted(expected)}."
+        )
     if train_count != len(y_train) or test_count != len(y_test):
         raise ValueError(
             f"HF preprocessor output validation failed for task '{hf_task}': feature/label batch mismatch."

--- a/mlaas_data_generator/federated/strategies/hf_strategy.py
+++ b/mlaas_data_generator/federated/strategies/hf_strategy.py
@@ -276,6 +276,35 @@ class HFStrategy(TaskStrategy):
 
     def train_client(self, client_id, x, y, global_model, round_idx, rounds_so_far, comm_down):
         samples_count = len(y)
+        if samples_count == 0:
+            weighting = self._resolve_client_weighting(samples_count, {})
+            return ClientOutcome(
+                participated=False,
+                fail_reason="Client received zero samples after preprocessing/partitioning",
+                samples_count=samples_count,
+                duration=0.0,
+                loss=np.nan,
+                metric_value=np.nan,
+                metric_score=np.nan,
+                extra_metric=np.nan,
+                rounds_so_far=rounds_so_far - 1,
+                comm_down=(0 if self.inference_only else comm_down),
+                comm_up=0,
+                cpu_time_s=0.0,
+                cpu_utilization=0.0,
+                memory_used_mb=0.0,
+                memory_utilization=0.0,
+                gpu_utilization=0.0,
+                gpu_memory_utilization=0.0,
+                gpu_memory_used_mb=0.0,
+                peak_vram_mb=0.0,
+                avg_vram_mb=0.0,
+                peak_host_ram_mb=0.0,
+                avg_host_ram_mb=0.0,
+                payload=None,
+                extras={},
+                **weighting,
+            )
 
         start = time.time()
         tracker = ResourceTracker()


### PR DESCRIPTION
### Motivation
- Prevent downstream NaN-only training/eval runs by surfacing zero-data root causes early in the HF preprocessing and federated client flow.
- Make failure modes explicit and human-readable to help debugging when a split contains zero samples after preprocessing/partitioning.

### Description
- Added a guard in `mlaas_data_generator/data/preprocessors/hf.py::_validate_hf_preprocessor_output` that raises a `ValueError` when either `train_count` or `test_count` is zero, and includes `hf_task`, split names, counts, and expected feature keys in the message.
- Added a client-level early exit in `mlaas_data_generator/federated/strategies/hf_strategy.py::train_client` that returns a non-participating `ClientOutcome` when `samples_count == 0` with `fail_reason="Client received zero samples after preprocessing/partitioning"`, `payload=None`, and no adapter `fit`/`evaluate` calls.
- Both changes preserve existing error semantics for missing keys, label mismatches, and feature/label length mismatches.

### Testing
- Compiled modified files with `python -m compileall mlaas_data_generator/data/preprocessors/hf.py mlaas_data_generator/federated/strategies/hf_strategy.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdccf53288330ba981790496160d1)