### PR TITLE
Resolve orchestrator metric-key via canonical task-family/HF-task mapping

### DIFF
--- a/mlaas_data_generator/federated/orchestrator.py
+++ b/mlaas_data_generator/federated/orchestrator.py
@@ -160,19 +160,30 @@ class FederatedDataGenerator:
         )
         self.task_family = canonical_task_family(self.task_type, self.hf_task)
 
-        # metric keys
-        if self.task_type == "clustering":
-            self.metric_key = "silhouette"
-            self.metric_label = "Silhouette"
-        elif self.task_family == "generation" and self.hf_task == "causal_lm_generation":
-            self.metric_key = "loss"
-            self.metric_label = "Loss"
-        elif self.task_type == "classification":
-            self.metric_key = "accuracy"
-            self.metric_label = "Accuracy"
-        else:
-            self.metric_key = "rmse"
-            self.metric_label = "RMSE"
+        # metric keys: resolve from canonical task-family/HF-task mapping.
+        task_tag = str(
+            self.config.get("task_tag")
+            or self.dataset_args.get("task_tag")
+            or ""
+        ).strip().lower() or None
+        metric_primary_name, _metric_secondary_name = canonical_metric_names(
+            self.task_family,
+            "metric",
+            hf_task=self.hf_task,
+            task_tag=task_tag,
+        )
+        self.metric_key = metric_primary_name
+
+        metric_label_overrides = {
+            "rmse": "RMSE",
+            "f1": "F1",
+            "iou": "IoU",
+            "map": "mAP",
+        }
+        self.metric_label = metric_label_overrides.get(
+            self.metric_key,
+            self.metric_key.replace("_", " ").title(),
+        )
 
         # strategy encapsulates build/train/eval details
         self.strategy = make_task_strategy(


### PR DESCRIPTION
### Motivation
- Unify metric selection in the orchestrator with the canonical metric taxonomy used by strategies so persisted global/client metric columns are semantically correct.
- Ensure task-family / HF-task / `task_tag` combinations (classification, token-classification, fill-mask, generation, detection, segmentation, retrieval, vqa, regression, clustering, etc.) pick the same primary metric name as `canonical_metric_names(...)`.
- Provide readable metric labels (e.g. `RMSE`, `F1`, `IoU`, `mAP`) while falling back to reasonable title-cased labels for other metric keys.

### Description
- Replaced the previous hard-coded metric-key branching in `FederatedDataGenerator` with resolution via `canonical_metric_names(self.task_family, "metric", hf_task=self.hf_task, task_tag=task_tag)` to compute `self.metric_key`.
- Compute `task_tag` from `self.config` or `self.dataset_args` and pass it into `canonical_metric_names(...)` so generation-subtypes and tagged tasks behave correctly.
- Add a small `metric_label_overrides` mapping to normalize acronym-style labels (`rmse` -> `RMSE`, `f1` -> `F1`, `iou` -> `IoU`, `map` -> `mAP`) and otherwise title-case the metric key for `self.metric_label`.
- Continue to pass `self.metric_key` into the task strategy initialization so strategy behavior remains unchanged but now shares a single source of truth for metric naming.

### Testing
- Compiled the modified modules with `python -m compileall mlaas_data_generator/federated/orchestrator.py mlaas_data_generator/federated/strategies/base.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdd54e63c833085d328c1756cdac5)