### PR TITLE
Make HFStrategy run params modality-aware (image & multimodal logging)

### DIFF
--- a/mlaas_data_generator/federated/strategies/hf_strategy.py
+++ b/mlaas_data_generator/federated/strategies/hf_strategy.py
@@ -129,6 +129,21 @@ class HFStrategy(TaskStrategy):
 
     def loggable_run_params(self):
         ds_args = self.config.get("dataset_args", {}) or {}
+        task = str(self.hf_task or "").strip().lower().replace("-", "_")
+
+        inferred_modality = ((self.meta or {}).get("modality") if isinstance(self.meta, dict) else None)
+        inferred_modality = str(inferred_modality or "").strip().lower()
+        if inferred_modality not in {"text", "image", "multimodal"}:
+            image_tasks = {"image_classification", "image_detection", "image_segmentation"}
+            multimodal_tasks = {"image_captioning", "text_image_retrieval", "visual_question_answering", "multimodal"}
+            if task in image_tasks:
+                inferred_modality = "image"
+            elif task in multimodal_tasks:
+                inferred_modality = "multimodal"
+            else:
+                inferred_modality = "text"
+
+        uses_tokenization = inferred_modality in {"text", "multimodal"}
 
         hf_model_id = ds_args.get("hf_model_id") or self.config.get("hf_model_id")
         max_length  = ds_args.get("max_length") or self.config.get("max_length")
@@ -152,22 +167,33 @@ class HFStrategy(TaskStrategy):
             "top_p": ds_args.get("top_p") or self.config.get("top_p"),
             "length_penalty": ds_args.get("length_penalty") or self.config.get("length_penalty"),
             "max_train_time_s": self.knobs.get("max_train_time_s", self.config.get("max_train_time_s", 60)),
-            "padding_mode": ("dynamic" if ds_args.get("dynamic_padding") else "max_length"),
             "aggregation_weight_unit": self._weighting_policy(),
         }
+        if uses_tokenization:
+            adapter["padding_mode"] = ("dynamic" if ds_args.get("dynamic_padding") else "max_length")
 
         dataset = {
             "dataset_name": ds_args.get("dataset_name"),
             "dataset_config": ds_args.get("dataset_config"),
             "train_split": ds_args.get("train_split"),
             "test_split": ds_args.get("test_split"),
-            "text_column": ds_args.get("text_column"),
-            "tokens_column": ds_args.get("tokens_column"),
-            "label_column": ds_args.get("label_column"),
             "max_samples": ds_args.get("max_samples"),
-            "dynamic_padding": ds_args.get("dynamic_padding"),
-            "padding_mode": ("dynamic" if ds_args.get("dynamic_padding") else "max_length"),
         }
+        if inferred_modality in {"text", "multimodal"}:
+            dataset["text_column"] = ds_args.get("text_column")
+            dataset["tokens_column"] = ds_args.get("tokens_column")
+        if inferred_modality in {"image", "multimodal"}:
+            dataset["image_column"] = ds_args.get("image_column")
+            dataset["boxes_column"] = ds_args.get("boxes_column")
+            dataset["classes_column"] = ds_args.get("classes_column")
+            dataset["mask_column"] = ds_args.get("mask_column")
+        if inferred_modality in {"image", "multimodal"} or task in {"sequence_classification", "token_classification", "sentence_similarity"}:
+            dataset["label_column"] = ds_args.get("label_column")
+        if inferred_modality == "multimodal":
+            dataset["missing_pair_handling"] = ds_args.get("missing_pair_handling")
+        if uses_tokenization:
+            dataset["dynamic_padding"] = ds_args.get("dynamic_padding")
+            dataset["padding_mode"] = ("dynamic" if ds_args.get("dynamic_padding") else "max_length")
 
         adapter = {k: v for k, v in adapter.items() if v is not None}
         dataset = {k: v for k, v in dataset.items() if v is not None}

--- a/mlaas_data_generator/test/test_hf_strategy_weighting.py
+++ b/mlaas_data_generator/test/test_hf_strategy_weighting.py
@@ -126,3 +126,91 @@ def test_aggregate_and_eval_uses_sequence_weights_for_image_classification(monke
     assert math.isclose(primary, 0.75)
     assert math.isclose(score, 0.75)
     assert math.isclose(secondary, 0.5)
+
+
+def test_loggable_run_params_image_schema_omits_text_defaults():
+    strategy = HFStrategy(
+        meta={"modality": "image"},
+        knobs={"batch_size": 2, "local_epochs": 1, "learning_rate": 1e-4},
+        config={
+            "model_type": "hf_finetune",
+            "dataset_args": {
+                "hf_task": "image_detection",
+                "dataset_name": "dummy",
+                "image_column": "image",
+                "label_column": "label",
+                "boxes_column": "boxes",
+                "classes_column": "classes",
+            },
+        },
+        x_test=[],
+        y_test=[],
+        metric_key="accuracy",
+        save_weights=False,
+    )
+
+    params = strategy.loggable_run_params()
+    assert "padding_mode" not in params["adapter"]
+    assert params["dataset"]["image_column"] == "image"
+    assert params["dataset"]["boxes_column"] == "boxes"
+    assert params["dataset"]["classes_column"] == "classes"
+    assert "text_column" not in params["dataset"]
+    assert "tokens_column" not in params["dataset"]
+    assert "padding_mode" not in params["dataset"]
+
+
+def test_loggable_run_params_multimodal_includes_pair_integrity_and_both_schemas():
+    strategy = HFStrategy(
+        meta={"modality": "multimodal"},
+        knobs={"batch_size": 2, "local_epochs": 1, "learning_rate": 1e-4},
+        config={
+            "model_type": "hf_finetune",
+            "dataset_args": {
+                "hf_task": "visual_question_answering",
+                "dataset_name": "dummy",
+                "image_column": "image",
+                "text_column": "question",
+                "label_column": "answer",
+                "missing_pair_handling": "drop",
+                "dynamic_padding": True,
+            },
+        },
+        x_test=[],
+        y_test=[],
+        metric_key="accuracy",
+        save_weights=False,
+    )
+
+    params = strategy.loggable_run_params()
+    assert params["adapter"]["padding_mode"] == "dynamic"
+    assert params["dataset"]["image_column"] == "image"
+    assert params["dataset"]["text_column"] == "question"
+    assert params["dataset"]["label_column"] == "answer"
+    assert params["dataset"]["missing_pair_handling"] == "drop"
+    assert params["dataset"]["padding_mode"] == "dynamic"
+
+
+def test_loggable_run_params_infers_image_modality_from_hf_task():
+    strategy = HFStrategy(
+        meta={},
+        knobs={"batch_size": 2, "local_epochs": 1, "learning_rate": 1e-4},
+        config={
+            "model_type": "hf_finetune",
+            "dataset_args": {
+                "hf_task": "image_segmentation",
+                "dataset_name": "dummy",
+                "image_column": "image",
+                "mask_column": "mask",
+            },
+        },
+        x_test=[],
+        y_test=[],
+        metric_key="accuracy",
+        save_weights=False,
+    )
+
+    params = strategy.loggable_run_params()
+    assert params["dataset"]["image_column"] == "image"
+    assert params["dataset"]["mask_column"] == "mask"
+    assert "text_column" not in params["dataset"]
+    assert "padding_mode" not in params["adapter"]


### PR DESCRIPTION
### Motivation
- Ensure run summaries accurately reflect dataset semantics (text vs image vs multimodal) so logged schemas match real pipeline inputs and speed up empty-pipeline debugging.
- Avoid emitting text/tokenization defaults for pure image pipelines and only report `padding_mode` when tokenization/padding is actually used.

### Description
- Resolve an `inferred_modality` from `meta["modality"]` with a fallback that maps `hf_task` to `text`, `image`, or `multimodal` and compute `uses_tokenization` accordingly in `HFStrategy.loggable_run_params`.
- Emit `adapter` fields conditionally and only include `padding_mode` when `uses_tokenization` is true; retain other adapter fields as before. (`mlaas_data_generator/federated/strategies/hf_strategy.py`)
- Build `dataset` logging keys per modality: text keys (`text_column`, `tokens_column`) for text/multimodal, image keys (`image_column`, `boxes_column`, `classes_column`, `mask_column`) for image/multimodal, include `label_column` when applicable, and add multimodal `missing_pair_handling`/pair-integrity info.
- Added unit tests that assert image-only runs omit text/tokenization defaults, multimodal runs include both schemas and pair-integrity, and that modality can be inferred from `hf_task`. (`mlaas_data_generator/test/test_hf_strategy_weighting.py`)

### Testing
- Added tests in `mlaas_data_generator/test/test_hf_strategy_weighting.py` exercising the new logging behavior; these tests are included in the patch.
- Attempted to run `pytest -q mlaas_data_generator/test/test_hf_strategy_weighting.py` but collection failed due to the environment not locating the package root; rerunning with `PYTHONPATH=.` failed because the test environment lacks the `numpy` dependency; no test suite passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcddddcb18833097fec489683bed87)