### PR TITLE
Handle HF image processors that don't accept do_augment

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf_image.py
+++ b/mlaas_data_generator/data/preprocessors/hf_image.py
@@ -1,6 +1,7 @@
 from ..accounting import append_accounting_stage, finalize_accounting
 import io
 import os
+import inspect
 
 import numpy as np
 
@@ -99,18 +100,30 @@ def _process_split(
     images = []
     labels = []
     decode_errors = []
+    processor_call = getattr(image_processor, "__call__", None)
+    accepts_kwargs = False
+    accepted_params = set()
+    if callable(processor_call):
+        try:
+            sig = inspect.signature(processor_call)
+            accepts_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+            accepted_params = set(sig.parameters)
+        except (TypeError, ValueError):
+            accepts_kwargs = True
 
     for idx in range(len(ds)):
         row = ds[idx]
         try:
             image = _to_numpy_rgb(row.get(image_column))
-            proc = image_processor(
-                image,
-                return_tensors=None,
-                do_resize=True,
-                do_normalize=True,
-                do_augment=bool(training),
-            )
+            processor_kwargs = {
+                "return_tensors": None,
+                "do_resize": True,
+                "do_normalize": True,
+                "do_augment": bool(training),
+            }
+            if not accepts_kwargs and accepted_params:
+                processor_kwargs = {k: v for k, v in processor_kwargs.items() if k in accepted_params}
+            proc = image_processor(image, **processor_kwargs)
             pix = proc.get("pixel_values", proc)
             pix = np.asarray(pix, dtype=np.float32)
             if pix.ndim == 4:

--- a/mlaas_data_generator/test/test_hf_image_preprocessor.py
+++ b/mlaas_data_generator/test/test_hf_image_preprocessor.py
@@ -35,8 +35,25 @@ class FakeImageProcessor:
         return {"pixel_values": arr}
 
 
+class FakeImageProcessorNoAugmentArg:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+
+    def __call__(self, image, return_tensors=None, do_resize=True, do_normalize=True):
+        arr = np.asarray(image, dtype=np.float32)
+        if do_normalize and arr.max() > 1:
+            arr = arr / 255.0
+        return {"pixel_values": arr}
+
+
 def _install_fake_transformers():
     fake_mod = types.SimpleNamespace(AutoImageProcessor=FakeImageProcessor)
+    sys.modules["transformers"] = fake_mod
+
+
+def _install_fake_transformers_no_augment_arg():
+    fake_mod = types.SimpleNamespace(AutoImageProcessor=FakeImageProcessorNoAugmentArg)
     sys.modules["transformers"] = fake_mod
 
 
@@ -162,3 +179,27 @@ def test_image_task_dispatch_normalizes_detection_alias_with_wrong_modality():
     assert meta["hf_task"] == "image_detection"
     assert y_train[0]["boxes"].shape == (1, 4)
     assert y_test[0]["boxes"].shape == (0, 4)
+
+
+def test_image_preprocessor_handles_processors_without_do_augment_arg():
+    _install_fake_transformers_no_augment_arg()
+    train_rows = [{"image": np.zeros((2, 2, 3), dtype=np.uint8), "boxes": [[0, 0, 1, 1]], "classes": [1]}]
+    test_rows = [{"image": np.zeros((2, 2, 3), dtype=np.uint8), "boxes": [[0, 0, 1, 1]], "classes": [1]}]
+
+    train, test, meta = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "object_detection", "modality": "image", "task_type": "detection", "hf_id": "dummy"},
+        hf_model_id="dummy/vision",
+        boxes_column="boxes",
+        classes_column="classes",
+    )
+
+    x_train, y_train = train
+    x_test, y_test = test
+    assert x_train["pixel_values"].shape[0] == 1
+    assert x_test["pixel_values"].shape[0] == 1
+    assert len(y_train) == 1
+    assert len(y_test) == 1
+    assert meta["decode_report"]["train"]["failed"] == 0
+    assert meta["decode_report"]["test"]["failed"] == 0


### PR DESCRIPTION
### Motivation
- Some Hugging Face image processors do not accept optional kwargs such as `do_augment`, causing every sample to fail preprocessing and resulting in zero emitted samples for image tasks.
- The change aims to make HF image preprocessing resilient to different `AutoImageProcessor` `__call__` signatures so valid datasets are produced.

### Description
- Inspect the `image_processor.__call__` signature with `inspect.signature` and detect if it accepts `**kwargs` or which named parameters it accepts.
- Only pass the subset of `processor_kwargs` that the processor actually supports (notably avoiding passing `do_augment` when it is unsupported).
- Added `import inspect` and the signature-aware kwarg filtering logic in `_process_split` in `mlaas_data_generator/data/preprocessors/hf_image.py`.
- Added a regression test `test_image_preprocessor_handles_processors_without_do_augment_arg` and a `FakeImageProcessorNoAugmentArg` in `mlaas_data_generator/test/test_hf_image_preprocessor.py` to cover processors that omit the `do_augment` argument.

### Testing
- Ran the image preprocessor unit tests with `pytest -q mlaas_data_generator/test/test_hf_image_preprocessor.py` to exercise the new branch and regression case.
- The test run failed during collection in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdee998c883308e2388f23bdcebfa)