### PR TITLE
Handle structured object-detection targets in orchestrator summaries

### DIFF
--- a/mlaas_data_generator/data/distributions.py
+++ b/mlaas_data_generator/data/distributions.py
@@ -1,5 +1,63 @@
 import numpy as np
 
+def _maybe_detection_distribution(y):
+    """Return object-detection summary stats when labels are structured dicts."""
+    if y is None:
+        return None
+    if not isinstance(y, (list, tuple, np.ndarray)):
+        return None
+
+    samples = 0
+    total_boxes = 0
+    class_counts = {}
+    saw_detection_schema = False
+
+    for item in y:
+        if item is None:
+            continue
+        if not isinstance(item, dict):
+            return None
+        if "boxes" not in item and "labels" not in item:
+            return None
+        saw_detection_schema = True
+        samples += 1
+
+        boxes = item.get("boxes")
+        labels = item.get("labels")
+
+        if boxes is not None:
+            try:
+                total_boxes += int(len(boxes))
+            except Exception:
+                pass
+
+        if labels is None:
+            continue
+        try:
+            label_values = np.asarray(labels).reshape(-1)
+        except Exception:
+            label_values = labels if isinstance(labels, (list, tuple)) else []
+        for label in label_values:
+            if label is None:
+                continue
+            try:
+                label_id = int(label)
+            except Exception:
+                continue
+            class_counts[label_id] = class_counts.get(label_id, 0) + 1
+
+    if not saw_detection_schema:
+        return None
+
+    avg_boxes = float(total_boxes / max(1, samples))
+    return {
+        "samples": int(samples),
+        "total_boxes": int(total_boxes),
+        "avg_boxes_per_sample": avg_boxes,
+        "class_counts": dict(sorted(class_counts.items())),
+    }
+
+
 def get_mlm_masked_token_stats(y, *, ignore_index=-100, top_k=10):
     """Return MLM masking-oriented stats instead of class histograms."""
     if y is None:
@@ -136,6 +194,10 @@ def get_data_distribution(
     value_range=None,
     label_pad_value=-100,
 ):
+    detection_summary = _maybe_detection_distribution(y)
+    if detection_summary is not None:
+        return detection_summary
+
     # -------------------------
     # Regression path
     # -------------------------

--- a/mlaas_data_generator/federated/orchestrator.py
+++ b/mlaas_data_generator/federated/orchestrator.py
@@ -56,6 +56,34 @@ def _first_sample_shape(x_train):
     return tuple()
 
 
+def _can_compute_numeric_range(values) -> bool:
+    """Return True when values can be safely reduced via numeric min/max."""
+    if values is None:
+        return False
+    try:
+        arr = np.asarray(values)
+    except Exception:
+        return False
+    if arr.size == 0:
+        return False
+    if arr.dtype.kind in {"b", "i", "u", "f"}:
+        return True
+    try:
+        flat = arr.reshape(-1)
+    except Exception:
+        return False
+    for item in flat:
+        if item is None:
+            continue
+        if isinstance(item, Number):
+            continue
+        try:
+            float(item)
+        except Exception:
+            return False
+    return True
+
+
 class FederatedDataGenerator:
     """Generate MLaaS client records using a simple federated-learning loop."""
     def __init__(
@@ -116,15 +144,17 @@ class FederatedDataGenerator:
 
         # Regression: set value range for distribution summaries
         if self.task_type == "regression" or self.num_classes is None:
-            if len(self.y_train) > 0:
+            if _can_compute_numeric_range(self.y_train):
                 y_min = float(np.min(self.y_train))
                 y_max = float(np.max(self.y_train))
                 if y_min == y_max:
                     y_min -= 0.5
                     y_max += 0.5
                 self.distribution_range = (y_min, y_max)
-            else:
+            elif self.task_type == "regression":
                 self.distribution_range = (0.0, 1.0)
+            else:
+                self.distribution_range = None
         else:
             self.distribution_range = None
 

--- a/mlaas_data_generator/test/test_distribution_summaries.py
+++ b/mlaas_data_generator/test/test_distribution_summaries.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mlaas_data_generator.data.distributions import get_token_label_stats
+from mlaas_data_generator.data.distributions import get_data_distribution, get_token_label_stats
 
 
 def test_get_token_label_stats_ignores_ignore_and_pad_tokens():
@@ -16,3 +16,17 @@ def test_get_token_label_stats_ignores_ignore_and_pad_tokens():
     assert stats["unique_supervised_token_ids"] == 2
     assert stats["top_supervised_token_ids"] == {13: 2, 11: 2} or stats["top_supervised_token_ids"] == {11: 2, 13: 2}
     assert stats["supervised_ratio"] == 0.5
+
+
+def test_get_data_distribution_detection_dict_targets():
+    y = [
+        {"boxes": [[0, 0, 10, 10], [10, 10, 20, 20]], "labels": [1, 2]},
+        {"boxes": [[0, 0, 8, 8]], "labels": [2]},
+    ]
+
+    stats = get_data_distribution(y, num_classes=None)
+
+    assert stats["samples"] == 2
+    assert stats["total_boxes"] == 3
+    assert stats["avg_boxes_per_sample"] == 1.5
+    assert stats["class_counts"] == {1: 1, 2: 2}


### PR DESCRIPTION
### Motivation
- Object-detection labels are structured dicts (e.g. `{"boxes":..., "labels":...}`) and attempting numeric reductions like `np.min(self.y_train)` raises `TypeError` because dicts are not orderable. 
- The orchestrator and distribution summary logic assumed scalar numeric labels and needs to be robust for detection, segmentation, captioning, etc.

### Description
- Add `_can_compute_numeric_range(values)` to `mlaas_data_generator/federated/orchestrator.py` and guard numeric `min`/`max` range computation so it runs only for truly numeric label arrays. 
- Adjust `FederatedDataGenerator` logic to skip distribution range computation when targets are non-numeric and to only use the default regression fallback when appropriate. 
- Add `_maybe_detection_distribution(y)` to `mlaas_data_generator/data/distributions.py` to detect structured detection labels and return a detection-aware summary containing `samples`, `total_boxes`, `avg_boxes_per_sample`, and `class_counts`. 
- Wire the detection summary into `get_data_distribution(...)` so dict-based detection targets are summarized instead of forced through numeric histogram code, and add a unit test `test_get_data_distribution_detection_dict_targets` in `mlaas_data_generator/test/test_distribution_summaries.py` to cover the new behavior.

### Testing
- Ran `pytest -q mlaas_data_generator/test/test_distribution_summaries.py`; the run failed during test collection with `ModuleNotFoundError: No module named 'numpy'` in this environment, so the new unit test could not be executed here.  
- The change is small, localized, and adds a direct unit test for detection dict targets which should pass in an environment with the project test dependencies installed (`numpy`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1fc5822c8330bf9aa62598417aad)