### PR TITLE
Allow HF object detection model initialization when num_labels is missing

### DIFF
--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -437,15 +437,18 @@ class ImageClassificationSpec(HFTaskSpec):
 class ObjectDetectionSpec(HFTaskSpec):
     name = "image_detection"
     requires_tokenizer = False
+    requires_num_labels = False
 
     def __init__(self, score_threshold=0.05):
         self.score_threshold = float(score_threshold)
 
     def build_model(self, transformers, model_id, num_labels):
+        kwargs = {"ignore_mismatched_sizes": True}
+        if num_labels is not None:
+            kwargs["num_labels"] = int(num_labels)
         return transformers.AutoModelForObjectDetection.from_pretrained(
             model_id,
-            num_labels=int(num_labels),
-            ignore_mismatched_sizes=True,
+            **kwargs,
         )
 
     def encode_batch(self, tokenizer, xb, yb, max_length, torch, device, ignore_index=-100, inference_only=False):

--- a/mlaas_data_generator/test/test_hf_image_task_specs.py
+++ b/mlaas_data_generator/test/test_hf_image_task_specs.py
@@ -47,3 +47,22 @@ def test_image_specs_do_not_require_tokenizer():
     assert ImageClassificationSpec.requires_tokenizer is False
     assert ObjectDetectionSpec.requires_tokenizer is False
     assert ImageSegmentationSpec.requires_tokenizer is False
+
+
+def test_object_detection_does_not_require_num_labels_and_builds_without_it():
+    class _AutoModelForObjectDetection:
+        called_kwargs = None
+
+        @classmethod
+        def from_pretrained(cls, model_id, **kwargs):
+            cls.called_kwargs = kwargs
+            return {"model_id": model_id, "kwargs": kwargs}
+
+    class _Transformers:
+        AutoModelForObjectDetection = _AutoModelForObjectDetection
+
+    spec = ObjectDetectionSpec()
+    assert spec.requires_num_labels is False
+    model = spec.build_model(_Transformers, "fake/model", num_labels=None)
+    assert model["model_id"] == "fake/model"
+    assert "num_labels" not in _AutoModelForObjectDetection.called_kwargs


### PR DESCRIPTION
### Motivation

- Object-detection tasks could leave `self.model` unset when label cardinality (`num_labels`) could not be inferred, causing downstream failures like `AttributeError("'NoneType' object has no attribute 'state_dict'")` during orchestration. 
- The intent is to allow HF object-detection models to be instantiated using the default model configuration when `num_labels` is not provided.

### Description

- Mark `ObjectDetectionSpec` as not requiring label cardinality by setting `requires_num_labels = False` in `mlaas_data_generator/models/adapters/hf_task.py`.
- Make `build_model` conditional so it only passes `num_labels` to `transformers.AutoModelForObjectDetection.from_pretrained(...)` when `num_labels` is not `None`, otherwise rely on the model repo defaults.
- Add a unit test `test_object_detection_does_not_require_num_labels_and_builds_without_it` to `mlaas_data_generator/test/test_hf_image_task_specs.py` that verifies `ObjectDetectionSpec` can build with `num_labels=None` and does not forward a `num_labels` kwarg.

### Testing

- Ran `pytest -q mlaas_data_generator/test/test_hf_image_task_specs.py`; test collection failed with `ModuleNotFoundError: No module named 'numpy'` in this environment, so the new test could not be executed here.
- The changes are limited to the HF task adapter and its tests, and the added unit test should pass in an environment with test dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de239612208330ac4838c7504a8ec8)