### PR TITLE
Avoid eager full-split stacking for HF object detection images

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf_image.py
+++ b/mlaas_data_generator/data/preprocessors/hf_image.py
@@ -264,49 +264,39 @@ def _process_split(
         labels.append(label)
 
     if on_decode_error != "report":
+        # Object detection datasets can include thousands of high-resolution images.
+        # Stacking the full split into one contiguous NCHW tensor eagerly allocates
+        # all pixel storage at once and can exhaust host RAM before batching.
+        #
+        # Keep detection pixel values as a per-sample list and let the training loop
+        # materialize tensor batches lazily in HFCore._batch_iter/encode_batch.
         if task_type == "detection":
-            LOGGER.info(
-                "[detection preprocessing] split=%s before np.stack(images) count=%d",
-                split_name,
-                len(images),
-            )
-        try:
-            stacked_images = np.stack(images, axis=0).astype(np.float32, copy=False)
-        except ValueError:
-            if task_type == "detection":
-                LOGGER.info(
-                    "[detection preprocessing] split=%s np.stack failed; investigating shapes before recovery",
-                    split_name,
-                )
-            unique_shapes = sorted({tuple(np.asarray(img).shape) for img in images})
-            channel_counts = {shape[0] for shape in unique_shapes if len(shape) == 3}
-            if channel_counts != {3}:
-                raise ValueError(
-                    "pixel values have inconsistent non-CHW shapes after preprocessing. "
-                    f"observed shapes={unique_shapes}"
-                )
+            x = {"pixel_values": images}
+        else:
+            try:
+                stacked_images = np.stack(images, axis=0).astype(np.float32, copy=False)
+            except ValueError:
+                unique_shapes = sorted({tuple(np.asarray(img).shape) for img in images})
+                channel_counts = {shape[0] for shape in unique_shapes if len(shape) == 3}
+                if channel_counts != {3}:
+                    raise ValueError(
+                        "pixel values have inconsistent non-CHW shapes after preprocessing. "
+                        f"observed shapes={unique_shapes}"
+                    )
 
-            max_h = max(shape[1] for shape in unique_shapes)
-            max_w = max(shape[2] for shape in unique_shapes)
-            padded_images = []
-            for image in images:
-                if task_type == "detection":
-                    LOGGER.info("[detection preprocessing] split=%s before np.asarray(image) for padding", split_name)
-                arr = np.asarray(image, dtype=np.float32)
-                if arr.shape[1] == max_h and arr.shape[2] == max_w:
-                    padded_images.append(arr)
-                    continue
-                pad_h = max_h - arr.shape[1]
-                pad_w = max_w - arr.shape[2]
-                padded_images.append(np.pad(arr, ((0, 0), (0, pad_h), (0, pad_w)), mode="constant"))
-            if task_type == "detection":
-                LOGGER.info(
-                    "[detection preprocessing] split=%s before np.stack(padded_images) count=%d",
-                    split_name,
-                    len(padded_images),
-                )
-            stacked_images = np.stack(padded_images, axis=0).astype(np.float32, copy=False)
-        x = {"pixel_values": stacked_images}
+                max_h = max(shape[1] for shape in unique_shapes)
+                max_w = max(shape[2] for shape in unique_shapes)
+                padded_images = []
+                for image in images:
+                    arr = np.asarray(image, dtype=np.float32)
+                    if arr.shape[1] == max_h and arr.shape[2] == max_w:
+                        padded_images.append(arr)
+                        continue
+                    pad_h = max_h - arr.shape[1]
+                    pad_w = max_w - arr.shape[2]
+                    padded_images.append(np.pad(arr, ((0, 0), (0, pad_h), (0, pad_w)), mode="constant"))
+                stacked_images = np.stack(padded_images, axis=0).astype(np.float32, copy=False)
+            x = {"pixel_values": stacked_images}
     else:
         x = {"pixel_values": images}
     if task_type == "classification":

--- a/mlaas_data_generator/test/test_hf_image_preprocessor.py
+++ b/mlaas_data_generator/test/test_hf_image_preprocessor.py
@@ -217,8 +217,8 @@ def test_image_preprocessor_handles_processors_without_do_augment_arg():
 
     x_train, y_train = train
     x_test, y_test = test
-    assert x_train["pixel_values"].shape[0] == 1
-    assert x_test["pixel_values"].shape[0] == 1
+    assert len(x_train["pixel_values"]) == 1
+    assert len(x_test["pixel_values"]) == 1
     assert len(y_train) == 1
     assert len(y_test) == 1
     assert meta["decode_report"]["train"]["failed"] == 0


### PR DESCRIPTION
### Motivation
- Large object-detection splits with high-resolution images were causing enormous single-array allocations (e.g. 29.8 GiB for shape `(1500, 3, 1333, 1333)`) during preprocessing. 
- The goal is to avoid exhausting host RAM during preprocessing by deferring tensor materialization until batching time for detection tasks.

### Description
- Changed `_process_split` in `mlaas_data_generator/data/preprocessors/hf_image.py` to keep `pixel_values` as a per-sample Python list when `task_type == "detection"` instead of eagerly `np.stack`-ing the entire split. 
- Kept the eager `np.stack` + pad-and-stack recovery path for non-detection image tasks to preserve existing behavior. 
- Added explanatory comments to document the memory rationale and the deferred materialization approach. 
- Updated `mlaas_data_generator/test/test_hf_image_preprocessor.py` assertions to validate `len(x_train["pixel_values"])` / `len(x_test["pixel_values"])` for detection scenarios instead of indexing into an ndarray.

### Testing
- Ran `pytest -q mlaas_data_generator/test/test_hf_image_preprocessor.py` in the environment, which failed during collection with `ModuleNotFoundError: No module named 'numpy'` so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de24775a408330a56b994c53b8b0ac)