### PR TITLE
Support varied object-detection annotation schemas and robust label handling

### DIFF
--- a/mlaas_data_generator/data/distributions.py
+++ b/mlaas_data_generator/data/distributions.py
@@ -1,5 +1,53 @@
 import numpy as np
 
+
+def _first_present(mapping, keys):
+    if not isinstance(mapping, dict):
+        return None
+    for key in keys:
+        if key in mapping:
+            return mapping.get(key)
+    return None
+
+
+def _extract_detection_fields(item):
+    if not isinstance(item, dict):
+        return None, None, False
+
+    box_keys = ("boxes", "bbox", "bboxes")
+    class_keys = ("labels", "classes", "class_labels", "category", "category_id", "category_ids")
+
+    boxes = None
+    labels = None
+    saw_schema = False
+    stack = [item]
+    visited = set()
+    while stack:
+        current = stack.pop()
+        if not isinstance(current, dict):
+            continue
+        current_id = id(current)
+        if current_id in visited:
+            continue
+        visited.add(current_id)
+
+        current_boxes = _first_present(current, box_keys)
+        current_labels = _first_present(current, class_keys)
+        if current_boxes is not None:
+            boxes = current_boxes
+            saw_schema = True
+        if current_labels is not None:
+            labels = current_labels
+            saw_schema = True
+
+        for container_key in ("annotation", "objects", "annotations", "targets"):
+            nested = current.get(container_key)
+            if isinstance(nested, dict):
+                stack.append(nested)
+
+    return boxes, labels, saw_schema
+
+
 def _maybe_detection_distribution(y):
     """Return object-detection summary stats when labels are structured dicts."""
     if y is None:
@@ -15,15 +63,11 @@ def _maybe_detection_distribution(y):
     for item in y:
         if item is None:
             continue
-        if not isinstance(item, dict):
-            return None
-        if "boxes" not in item and "labels" not in item:
+        boxes, labels, saw_schema = _extract_detection_fields(item)
+        if not saw_schema:
             return None
         saw_detection_schema = True
         samples += 1
-
-        boxes = item.get("boxes")
-        labels = item.get("labels")
 
         if boxes is not None:
             try:
@@ -36,7 +80,7 @@ def _maybe_detection_distribution(y):
         try:
             label_values = np.asarray(labels).reshape(-1)
         except Exception:
-            label_values = labels if isinstance(labels, (list, tuple)) else []
+            label_values = labels if isinstance(labels, (list, tuple, np.ndarray)) else [labels]
         for label in label_values:
             if label is None:
                 continue

--- a/mlaas_data_generator/data/preprocessors/hf_image.py
+++ b/mlaas_data_generator/data/preprocessors/hf_image.py
@@ -96,6 +96,41 @@ def _normalise_detection_item(boxes, classes):
     return {"boxes": out_boxes, "classes": out_classes}
 
 
+def _extract_detection_annotations(row, *, label_column=None, boxes_column=None, classes_column=None):
+    boxes = row.get(boxes_column) if boxes_column else None
+    classes = row.get(classes_column) if classes_column else None
+
+    if boxes is not None or classes is not None:
+        return _normalise_detection_item(boxes, classes)
+
+    annotation = row.get(label_column) if label_column else None
+    if not isinstance(annotation, dict):
+        return _normalise_detection_item([], [])
+
+    for container_key in ("objects", "annotations", "targets"):
+        nested = annotation.get(container_key)
+        if isinstance(nested, dict):
+            annotation = nested
+            break
+
+    candidate_boxes_keys = ("boxes", "bbox", "bboxes")
+    candidate_classes_keys = ("classes", "class_labels", "labels", "category", "category_id", "category_ids")
+
+    extracted_boxes = None
+    for key in candidate_boxes_keys:
+        if key in annotation:
+            extracted_boxes = annotation.get(key)
+            break
+
+    extracted_classes = None
+    for key in candidate_classes_keys:
+        if key in annotation:
+            extracted_classes = annotation.get(key)
+            break
+
+    return _normalise_detection_item(extracted_boxes, extracted_classes)
+
+
 def _process_split(
     ds,
     *,
@@ -235,7 +270,12 @@ def _process_split(
                     split_name,
                     idx,
                 )
-                label = _normalise_detection_item(row.get(boxes_column), row.get(classes_column))
+                label = _extract_detection_annotations(
+                    row,
+                    label_column=label_column,
+                    boxes_column=boxes_column,
+                    classes_column=classes_column,
+                )
             elif task_type == "segmentation":
                 mask = row.get(mask_column)
                 if mask is None:

--- a/mlaas_data_generator/models/adapters/hf_core.py
+++ b/mlaas_data_generator/models/adapters/hf_core.py
@@ -151,6 +151,26 @@ class HFCore:
             yb = None if ys is None else ys[i:i + bs]
             yield xb, yb
 
+    def _labels_to_numpy(self, labels_t):
+        if labels_t is None:
+            return None
+        if hasattr(labels_t, "detach"):
+            return labels_t.detach().cpu().numpy()
+        if isinstance(labels_t, (list, tuple)):
+            converted = []
+            for item in labels_t:
+                if isinstance(item, dict):
+                    converted.append(
+                        {
+                            k: (v.detach().cpu().numpy() if hasattr(v, "detach") else np.asarray(v))
+                            for k, v in item.items()
+                        }
+                    )
+                else:
+                    converted.append(item.detach().cpu().numpy() if hasattr(item, "detach") else np.asarray(item))
+            return np.asarray(converted, dtype=object)
+        return np.asarray(labels_t)
+
     def _debug_shape(self, value):
         if value is None:
             return None
@@ -351,8 +371,11 @@ class HFCore:
     def finetune(self, xs, ys, epochs=1, lr=5e-5, max_train_time_s=60):
         torch = self.torch
 
+        def _is_dense_label_tensor(value):
+            return hasattr(value, "ndim") and not isinstance(value, (list, tuple, dict))
+
         def _count_supervised_tokens(labels_t, ignore_index):
-            if labels_t is None or labels_t.ndim < 2:
+            if not _is_dense_label_tensor(labels_t) or labels_t.ndim < 2:
                 return 0
             return int((labels_t != int(ignore_index)).sum().detach().cpu().item())
 
@@ -407,7 +430,7 @@ class HFCore:
                     sequence_count = len(xb)
                 train_sequence_count += int(sequence_count)
 
-                if isinstance(labels_t, torch.Tensor) and labels_t.ndim >= 2:
+                if _is_dense_label_tensor(labels_t) and labels_t.ndim >= 2:
                     loss_denominator_count = supervised_token_count
                 else:
                     loss_denominator_count = sequence_count
@@ -468,8 +491,11 @@ class HFCore:
     def eval(self, xs, ys, inference_only=False, max_eval_time_s=None, progress_log_interval=None):
         torch = self.torch
 
+        def _is_dense_label_tensor(value):
+            return hasattr(value, "ndim") and not isinstance(value, (list, tuple, dict))
+
         def _count_supervised_tokens(labels_t, ignore_index):
-            if labels_t is None or labels_t.ndim < 2:
+            if not _is_dense_label_tensor(labels_t) or labels_t.ndim < 2:
                 return 0
             return int((labels_t != int(ignore_index)).sum().detach().cpu().item())
 
@@ -546,7 +572,7 @@ class HFCore:
                     )
                     teacher_forced = (teacher_enc, teacher_labels_t, dict(teacher_extra or {}))
                     if teacher_labels_t is not None:
-                        labels_all.append(teacher_labels_t.detach().cpu().numpy())
+                        labels_all.append(self._labels_to_numpy(teacher_labels_t))
                         labels_recorded = True
                         supervised_token_count = _count_supervised_tokens(teacher_labels_t, self.label_pad_value)
                         eval_supervised_token_count += supervised_token_count
@@ -587,7 +613,7 @@ class HFCore:
 
                         loss = self.task_spec.extract_loss(torch, outputs, logits, teacher_labels_t, teacher_extra)
                         if loss is not None:
-                            if teacher_labels_t.ndim >= 2:
+                            if _is_dense_label_tensor(teacher_labels_t) and teacher_labels_t.ndim >= 2:
                                 loss_denominator_count = supervised_token_count
                             elif isinstance(xb, dict):
                                 loss_denominator_count = len(next(iter(xb.values())))
@@ -620,12 +646,12 @@ class HFCore:
 
                         loss = self.task_spec.extract_loss(torch, outputs, logits, labels_t, extra)
                         if loss is not None and labels_t is not None:
-                            labels_all.append(labels_t.detach().cpu().numpy())
+                            labels_all.append(self._labels_to_numpy(labels_t))
                             labels_recorded = True
                             supervised_token_count = _count_supervised_tokens(labels_t, self.label_pad_value)
                             eval_supervised_token_count += supervised_token_count
 
-                            if labels_t.ndim >= 2:
+                            if _is_dense_label_tensor(labels_t) and labels_t.ndim >= 2:
                                 loss_denominator_count = supervised_token_count
                             elif isinstance(xb, dict):
                                 loss_denominator_count = len(next(iter(xb.values())))
@@ -636,7 +662,7 @@ class HFCore:
                             eval_loss_denominator_count += int(max(1, loss_denominator_count))
 
                 if labels_t is not None and bool(inference_only) and yb is not None and not labels_recorded:
-                    labels_all.append(labels_t.detach().cpu().numpy())
+                    labels_all.append(self._labels_to_numpy(labels_t))
 
                 latencies_ms.append((time.time() - t0) * 1000.0)
                 if eval_batch_count and (
@@ -656,7 +682,10 @@ class HFCore:
 
         duration_s = time.time() - t_start
 
-        y_true_np = np.concatenate(labels_all, axis=0) if labels_all else np.asarray([], dtype="int64")
+        try:
+            y_true_np = np.concatenate(labels_all, axis=0) if labels_all else np.asarray([], dtype="int64")
+        except Exception:
+            y_true_np = np.asarray(labels_all, dtype=object) if labels_all else np.asarray([], dtype=object)
         y_pred_np = np.concatenate(preds_all, axis=0) if preds_all else np.asarray([], dtype="int64")
 
         named_metrics = None

--- a/mlaas_data_generator/test/test_distribution_summaries.py
+++ b/mlaas_data_generator/test/test_distribution_summaries.py
@@ -30,3 +30,29 @@ def test_get_data_distribution_detection_dict_targets():
     assert stats["total_boxes"] == 3
     assert stats["avg_boxes_per_sample"] == 1.5
     assert stats["class_counts"] == {1: 1, 2: 2}
+
+
+def test_get_data_distribution_detection_supports_classes_and_class_labels():
+    y = [
+        {"boxes": [[0, 0, 10, 10]], "classes": [5]},
+        {"bbox": [[1, 1, 8, 8]], "class_labels": [7]},
+    ]
+
+    stats = get_data_distribution(y, num_classes=None)
+
+    assert stats["samples"] == 2
+    assert stats["total_boxes"] == 2
+    assert stats["class_counts"] == {5: 1, 7: 1}
+
+
+def test_get_data_distribution_detection_supports_nested_annotation_schemas():
+    y = [
+        {"annotation": {"objects": {"bbox": [[0, 0, 10, 10]], "category": [3]}}},
+        {"annotation": {"annotations": {"boxes": [[2, 2, 6, 6]], "category_id": [4]}}},
+    ]
+
+    stats = get_data_distribution(y, num_classes=None)
+
+    assert stats["samples"] == 2
+    assert stats["total_boxes"] == 2
+    assert stats["class_counts"] == {3: 1, 4: 1}

--- a/mlaas_data_generator/test/test_hf_image_preprocessor.py
+++ b/mlaas_data_generator/test/test_hf_image_preprocessor.py
@@ -225,6 +225,37 @@ def test_image_preprocessor_handles_processors_without_do_augment_arg():
     assert meta["decode_report"]["test"]["failed"] == 0
 
 
+def test_image_detection_extracts_boxes_and_classes_from_annotation_column():
+    _install_fake_transformers()
+    train_rows = [
+        {
+            "image": np.zeros((2, 2, 3), dtype=np.uint8),
+            "annotation": {"objects": {"bbox": [[0, 0, 1, 1]], "category": [3]}},
+        }
+    ]
+    test_rows = [
+        {
+            "image": np.zeros((2, 2, 3), dtype=np.uint8),
+            "annotation": {"objects": {"bbox": [[0, 0, 1, 1]], "category_id": [4]}},
+        }
+    ]
+
+    train, test, _ = preprocess_hf(
+        (DummySplit(train_rows), None),
+        (DummySplit(test_rows), None),
+        {"hf_task": "object_detection", "modality": "image", "task_type": "detection", "hf_id": "dummy"},
+        hf_model_id="dummy/vision",
+        label_column="annotation",
+    )
+
+    _, y_train = train
+    _, y_test = test
+    assert y_train[0]["boxes"].shape == (1, 4)
+    assert y_train[0]["classes"].tolist() == [3]
+    assert y_test[0]["boxes"].shape == (1, 4)
+    assert y_test[0]["classes"].tolist() == [4]
+
+
 def test_image_preprocessor_filters_kwargs_against_preprocess_signature():
     _install_fake_transformers_call_kwargs_strict_preprocess()
     train_rows = [{"image": np.zeros((2, 2, 3), dtype=np.uint8), "label": 1}]


### PR DESCRIPTION
### Motivation
- Improve robustness for object-detection input schemas by recognizing common alternate keys and nested annotation containers. 
- Ensure downstream training/eval code safely converts labels from PyTorch tensors, lists, dicts or object arrays into numpy for metrics and aggregation.

### Description
- Add `_first_present` and `_extract_detection_fields` in `data/distributions.py` and update `_maybe_detection_distribution` to detect boxes/labels under alternate keys (`bbox`, `bboxes`, `classes`, `class_labels`, `category*`) and inside nested containers like `annotation`, `objects`, `annotations`, and `targets`.
- Add `_extract_detection_annotations` in `data/preprocessors/hf_image.py` and use it in `_process_split` to normalize detection rows coming from `label_column` or separate `boxes_column`/`classes_column` into a consistent `{"boxes": ndarray, "classes": ndarray}` format via `_normalise_detection_item`.
- Make label parsing more tolerant by treating lists/tuples/ndarrays uniformly when flattening label values.
- In `models/adapters/hf_core.py` add `_labels_to_numpy` helper and a small `_is_dense_label_tensor` predicate, and update `finetune`/`eval` to: convert labels (including lists of dicts / tensors) safely to numpy, compute supervised token counts only for dense label tensors, and fall back to object-dtype concatenation when `np.concatenate(labels_all, axis=0)` fails.

### Testing
- Added tests exercising detection distribution parsing for alternate keys and nested annotation schemas in `test_distribution_summaries.py` and a test extracting boxes/classes from `annotation` in `test_hf_image_preprocessor.py`.
- Ran the relevant unit tests (distribution and image preprocessor tests) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2a047edc83308605ce232e93ec81)