### PR TITLE
Normalize object-detection boxes and align formats to fix mAP=0

### DIFF
--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -489,11 +489,15 @@ class ObjectDetectionSpec(HFTaskSpec):
         labels_t = None
         if yb is not None:
             labels_t = []
-            for item in yb:
+            for idx, item in enumerate(yb):
+                image_h = int(pixel_arrays[idx].shape[1]) if idx < len(pixel_arrays) else 1
+                image_w = int(pixel_arrays[idx].shape[2]) if idx < len(pixel_arrays) else 1
+                boxes_xyxy_norm = self._to_xyxy_normalized(item.get("boxes", []), image_h=image_h, image_w=image_w)
+                boxes_cxcywh_norm = self._xyxy_to_cxcywh(boxes_xyxy_norm)
                 labels_t.append(
                     {
                         "class_labels": torch.tensor(item.get("classes", []), dtype=torch.long, device=device),
-                        "boxes": torch.tensor(item.get("boxes", []), dtype=torch.float32, device=device),
+                        "boxes": torch.tensor(boxes_cxcywh_norm, dtype=torch.float32, device=device),
                     }
                 )
         return enc, labels_t, {"score_threshold": self.score_threshold}
@@ -525,6 +529,60 @@ class ObjectDetectionSpec(HFTaskSpec):
         union = np.clip(area_a[:, None] + area_b[None, :] - inter, a_min=1e-9, a_max=None)
         return inter / union
 
+    @staticmethod
+    def _xyxy_to_cxcywh(boxes_xyxy):
+        if boxes_xyxy.size == 0:
+            return np.zeros((0, 4), dtype=np.float32)
+        x1, y1, x2, y2 = boxes_xyxy.T
+        w = np.clip(x2 - x1, a_min=0.0, a_max=None)
+        h = np.clip(y2 - y1, a_min=0.0, a_max=None)
+        cx = x1 + (w / 2.0)
+        cy = y1 + (h / 2.0)
+        return np.column_stack([cx, cy, w, h]).astype(np.float32, copy=False)
+
+    @staticmethod
+    def _cxcywh_to_xyxy(boxes_cxcywh):
+        if boxes_cxcywh.size == 0:
+            return np.zeros((0, 4), dtype=np.float32)
+        cx, cy, w, h = boxes_cxcywh.T
+        return np.column_stack([
+            cx - w / 2.0,
+            cy - h / 2.0,
+            cx + w / 2.0,
+            cy + h / 2.0,
+        ]).astype(np.float32, copy=False)
+
+    def _to_xyxy_normalized(self, boxes, image_h, image_w):
+        out_boxes = np.asarray(boxes, dtype=np.float32)
+        if out_boxes.size == 0:
+            return np.zeros((0, 4), dtype=np.float32)
+        if out_boxes.ndim == 1:
+            out_boxes = out_boxes.reshape(1, 4)
+        if out_boxes.ndim != 2 or out_boxes.shape[1] != 4:
+            raise ValueError(f"object detection boxes must be Nx4, got shape={out_boxes.shape}")
+
+        max_val = float(np.max(out_boxes))
+        monotonic_xyxy = bool(np.all(out_boxes[:, 2] >= out_boxes[:, 0]) and np.all(out_boxes[:, 3] >= out_boxes[:, 1]))
+        if max_val <= 1.5:
+            boxes_xyxy = out_boxes if monotonic_xyxy else self._cxcywh_to_xyxy(out_boxes)
+        else:
+            bounded_xyxy = (
+                monotonic_xyxy
+                and np.all(out_boxes[:, 0] <= float(image_w) * 1.05)
+                and np.all(out_boxes[:, 2] <= float(image_w) * 1.05)
+                and np.all(out_boxes[:, 1] <= float(image_h) * 1.05)
+                and np.all(out_boxes[:, 3] <= float(image_h) * 1.05)
+            )
+            if bounded_xyxy:
+                boxes_xyxy = out_boxes
+            else:
+                x, y, w, h = out_boxes.T
+                boxes_xyxy = np.column_stack([x, y, x + w, y + h])
+            boxes_xyxy[:, [0, 2]] /= max(float(image_w), 1e-9)
+            boxes_xyxy[:, [1, 3]] /= max(float(image_h), 1e-9)
+
+        return np.clip(boxes_xyxy, a_min=0.0, a_max=1.0).astype(np.float32, copy=False)
+
     def batch_metric_statistics_from_outputs(self, torch, outputs, labels_t, extra):
         if labels_t is None or outputs is None or not hasattr(outputs, "pred_boxes"):
             return None
@@ -539,6 +597,7 @@ class ObjectDetectionSpec(HFTaskSpec):
 
         for bidx, gt in enumerate(labels_t):
             gt_boxes = gt["boxes"].detach().cpu().numpy()
+            gt_boxes = self._cxcywh_to_xyxy(gt_boxes)
             gt_classes = gt["class_labels"].detach().cpu().numpy()
             stats["gt"] += float(len(gt_classes))
 
@@ -548,12 +607,7 @@ class ObjectDetectionSpec(HFTaskSpec):
             p_scores = p_scores[keep]
             p_cls = p_cls[keep]
             p_boxes = boxes[bidx][keep]
-            p_boxes = np.column_stack([
-                p_boxes[:, 0] - p_boxes[:, 2] / 2.0,
-                p_boxes[:, 1] - p_boxes[:, 3] / 2.0,
-                p_boxes[:, 0] + p_boxes[:, 2] / 2.0,
-                p_boxes[:, 1] + p_boxes[:, 3] / 2.0,
-            ]) if p_boxes.size else np.zeros((0, 4), dtype=np.float32)
+            p_boxes = self._cxcywh_to_xyxy(p_boxes)
 
             for thr in thresholds:
                 matched_gt = set()

--- a/mlaas_data_generator/test/test_hf_image_task_specs.py
+++ b/mlaas_data_generator/test/test_hf_image_task_specs.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 from mlaas_data_generator.models.adapters.hf_task import (
     ImageClassificationSpec,
@@ -66,3 +67,42 @@ def test_object_detection_does_not_require_num_labels_and_builds_without_it():
     model = spec.build_model(_Transformers, "fake/model", num_labels=None)
     assert model["model_id"] == "fake/model"
     assert "num_labels" not in _AutoModelForObjectDetection.called_kwargs
+
+
+def test_object_detection_encode_batch_converts_absolute_xywh_to_normalized_cxcywh():
+    spec = ObjectDetectionSpec()
+    xb = {"pixel_values": [np.zeros((3, 100, 200), dtype=np.float32)]}
+    yb = [{"boxes": [[20, 10, 40, 30]], "classes": [2]}]
+
+    _, labels_t, _ = spec.encode_batch(
+        tokenizer=None,
+        xb=xb,
+        yb=yb,
+        max_length=0,
+        torch=torch,
+        device=torch.device("cpu"),
+    )
+
+    boxes = labels_t[0]["boxes"].detach().cpu().numpy()
+    # xywh absolute [20,10,40,30] on (h=100,w=200) -> xyxy norm [0.1,0.1,0.3,0.4] -> cxcywh [0.2,0.25,0.2,0.3]
+    assert np.allclose(boxes, np.asarray([[0.2, 0.25, 0.2, 0.3]], dtype=np.float32), atol=1e-6)
+
+
+def test_object_detection_batch_metric_statistics_from_outputs_counts_true_positive():
+    spec = ObjectDetectionSpec(score_threshold=0.05)
+    labels_t = [
+        {
+            "class_labels": torch.tensor([1], dtype=torch.long),
+            "boxes": torch.tensor([[0.5, 0.5, 0.4, 0.4]], dtype=torch.float32),
+        }
+    ]
+
+    class _Outputs:
+        logits = torch.tensor([[[0.1, 5.0, -4.0]]], dtype=torch.float32)  # class 1 is top score, final index is no-object
+        pred_boxes = torch.tensor([[[0.5, 0.5, 0.4, 0.4]]], dtype=torch.float32)
+
+    stats = spec.batch_metric_statistics_from_outputs(torch, _Outputs(), labels_t, {"score_threshold": 0.05})
+    assert np.isclose(stats["gt"], 1.0)
+    assert np.isclose(stats["tp_0.5"], 1.0)
+    assert np.isclose(stats["tp_0.75"], 1.0)
+    assert np.isclose(stats["tp_0.95"], 1.0)


### PR DESCRIPTION
### Motivation
- Detection runs were producing `mAP = 0.0` because ground-truth boxes from datasets (e.g. COCO-style `xywh` in pixels) were passed through without a guaranteed, consistent normalization/format while model predictions were in normalized `cxcywh`, causing near-zero IoU and zero true positives.
- Provide robust heuristics to infer common box formats and convert labels/predictions into the same coordinate space so IoU matching and mAP computation are meaningful.

### Description
- Added conversion helpers `_xyxy_to_cxcywh`, `_cxcywh_to_xyxy`, and `_to_xyxy_normalized` to `ObjectDetectionSpec` for robust format inference and normalized conversions in `mlaas_data_generator/models/adapters/hf_task.py`.
- Changed `encode_batch` to convert dataset label boxes (handles absolute `xywh`, `xyxy`, and normalized variants) into normalized `cxcywh` before creating `labels_t` so training/eval labels match HF detection model expectations.
- Adjusted `batch_metric_statistics_from_outputs` to convert both ground-truth and predicted boxes into `xyxy` space before IoU computation to ensure correct TP/FP counting.
- Added unit tests in `mlaas_data_generator/test/test_hf_image_task_specs.py` that validate absolute `xywh` → normalized `cxcywh` conversion and a perfect-prediction case that yields true positives in metric statistics.

### Testing
- Compiled the modified modules with `python -m py_compile mlaas_data_generator/models/adapters/hf_task.py mlaas_data_generator/test/test_hf_image_task_specs.py`, which succeeded without syntax errors.
- Ran `pytest -q mlaas_data_generator/test/test_hf_image_task_specs.py` which could not complete in this environment because `numpy` (and related test deps) is not installed, so test collection failed; the new tests are included and expected to pass in a properly provisioned environment.
- The change set is focused on deterministic conversions and has unit tests added to catch regressions when run in CI with test dependencies present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de38a4a6d08330b9c78599227e0957)