### PR TITLE
Remap predicted contiguous class indices for COCO-style DETR models

### DIFF
--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -472,7 +472,7 @@ class ObjectDetectionSpec(HFTaskSpec):
         valid = [k for k in sorted(cleaned) if cleaned[k].strip().lower() != "n/a"]
         return valid or None
 
-    def _remap_contiguous_classes_if_needed(self, classes):
+    def _remap_contiguous_classes_if_needed(self, classes, *, force=False):
         class_ids = np.asarray(classes, dtype=np.int64)
         valid_ids = self._model_valid_class_ids
         if class_ids.size == 0 or not valid_ids:
@@ -485,8 +485,9 @@ class ObjectDetectionSpec(HFTaskSpec):
         if (
             valid_ids
             and valid_ids[0] == 1
-            and 0 in set(class_ids.tolist())
+            and int(np.min(class_ids)) >= 0
             and int(np.max(class_ids)) < len(valid_ids)
+            and (force or 0 in set(class_ids.tolist()))
         ):
             mapped = np.asarray([int(valid_ids[int(cid)]) for cid in class_ids], dtype=np.int64)
             return mapped
@@ -645,6 +646,7 @@ class ObjectDetectionSpec(HFTaskSpec):
 
             p_scores = probs[bidx, :, :-1].max(axis=-1)
             p_cls = probs[bidx, :, :-1].argmax(axis=-1)
+            p_cls = self._remap_contiguous_classes_if_needed(p_cls, force=True)
             keep = p_scores >= float(extra.get("score_threshold", self.score_threshold))
             p_scores = p_scores[keep]
             p_cls = p_cls[keep]

--- a/mlaas_data_generator/test/test_hf_image_task_specs.py
+++ b/mlaas_data_generator/test/test_hf_image_task_specs.py
@@ -108,6 +108,25 @@ def test_object_detection_batch_metric_statistics_from_outputs_counts_true_posit
     assert np.isclose(stats["tp_0.95"], 1.0)
 
 
+def test_object_detection_batch_metric_statistics_remaps_predicted_contiguous_ids_for_coco_models():
+    spec = ObjectDetectionSpec(score_threshold=0.05)
+    spec._model_valid_class_ids = [1, 2]
+    labels_t = [
+        {
+            "class_labels": torch.tensor([1], dtype=torch.long),
+            "boxes": torch.tensor([[0.5, 0.5, 0.4, 0.4]], dtype=torch.float32),
+        }
+    ]
+
+    class _Outputs:
+        # Predicted class index 0 should be remapped to model class id 1 when valid ids start at 1.
+        logits = torch.tensor([[[5.0, 0.1, -4.0]]], dtype=torch.float32)
+        pred_boxes = torch.tensor([[[0.5, 0.5, 0.4, 0.4]]], dtype=torch.float32)
+
+    stats = spec.batch_metric_statistics_from_outputs(torch, _Outputs(), labels_t, {"score_threshold": 0.05})
+    assert np.isclose(stats["tp_0.5"], 1.0)
+
+
 def test_object_detection_encode_batch_remaps_contiguous_coco_ids_when_model_uses_na_zero_slot():
     spec = ObjectDetectionSpec()
     # Mimic COCO-style id2label where index 0 is "N/A" and real classes start at 1.


### PR DESCRIPTION
### Motivation
- Pretrained COCO DETR-family checkpoints commonly expose `id2label` with index `0` = "N/A" while datasets use contiguous category indices starting at `0`, which caused predicted class indices to be compared against GT in different ID spaces and produced implausibly low mAP. 
- The evaluation should translate predicted contiguous indices into the model's label IDs before TP/FP matching so predictions align with ground truth.

### Description
- Changed `ObjectDetectionSpec._remap_contiguous_classes_if_needed` signature to accept a `force` flag (`def _remap_contiguous_classes_if_needed(self, classes, *, force=False)`), added a minimal-range check and made remapping conditional on `force` or presence of `0` in the input. 
- Applied forced remapping to predicted class arrays inside `batch_metric_statistics_from_outputs` so prediction-time indices are translated to model `id2label` IDs before IoU matching. 
- Added a regression unit test `test_object_detection_batch_metric_statistics_remaps_predicted_contiguous_ids_for_coco_models` in `test_hf_image_task_specs.py` that verifies a predicted contiguous index `0` is remapped to model class ID `1` when `spec._model_valid_class_ids` starts at `[1, ...]`.

### Testing
- Ran `pytest -q mlaas_data_generator/test/test_hf_image_task_specs.py` against the modified test file, but collection failed due to missing runtime dependency `numpy` in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de441821c88330bb3227d95de34340)