### PR TITLE
Fix HF image-classification sampling, class-count inference, and metric labeling

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf_image.py
+++ b/mlaas_data_generator/data/preprocessors/hf_image.py
@@ -446,9 +446,27 @@ def preprocess_hf_image(
     inferred_num_classes = None
     if task_type == "classification" and len(y_train) > 0:
         inferred_num_classes = int(np.unique(np.asarray(y_train)).size)
+    feature_num_classes = None
+    if task_type == "classification":
+        try:
+            label_feature = (getattr(ds_train, "features", None) or {}).get(label_column)
+            if label_feature is not None:
+                class_names = getattr(label_feature, "names", None)
+                if class_names:
+                    feature_num_classes = int(len(class_names))
+                else:
+                    num_classes_attr = getattr(label_feature, "num_classes", None)
+                    if num_classes_attr is not None:
+                        feature_num_classes = int(num_classes_attr)
+        except Exception:
+            feature_num_classes = None
+
     resolved_num_classes = meta.get("num_classes")
     if resolved_num_classes is None:
-        resolved_num_classes = inferred_num_classes
+        if feature_num_classes is not None and inferred_num_classes is not None:
+            resolved_num_classes = int(max(feature_num_classes, inferred_num_classes))
+        else:
+            resolved_num_classes = feature_num_classes if feature_num_classes is not None else inferred_num_classes
     meta.update(
         {
             "input_shape": inferred_input_shape,

--- a/mlaas_data_generator/data/sources/huggingface.py
+++ b/mlaas_data_generator/data/sources/huggingface.py
@@ -76,6 +76,10 @@ def load_huggingface_source(**kwargs):
 
     if max_samples:
         n = int(max_samples)
+        if len(ds_train) > 1:
+            ds_train = ds_train.shuffle(seed=seed)
+        if len(ds_test) > 1:
+            ds_test = ds_test.shuffle(seed=seed + 1)
         ds_train = ds_train.select(range(min(n, len(ds_train))))
         ds_test = ds_test.select(range(min(max(1, n // 5), len(ds_test))))
 

--- a/mlaas_data_generator/federated/strategies/base.py
+++ b/mlaas_data_generator/federated/strategies/base.py
@@ -98,6 +98,8 @@ def canonical_label_format(task_family: str) -> str:
 
 def canonical_metric_names(task_family: str, metric_key: str, *, hf_task: str | None = None, task_tag: str | None = None) -> tuple[str, str | None]:
     if task_family == "classification":
+        if normalize_hf_task(hf_task) == "image_classification":
+            return ("accuracy", "top5_accuracy")
         return ("accuracy", "f1")
     if task_family == "token_classification":
         return ("f1", "accuracy")

--- a/mlaas_data_generator/models/adapters/hf_core.py
+++ b/mlaas_data_generator/models/adapters/hf_core.py
@@ -699,7 +699,6 @@ class HFCore:
         m_stats = self.task_spec.metrics_from_statistics(stats_accum) if stats_accum else None
         if isinstance(m_stats, dict) and m_stats:
             print("[HFCore.eval] metric computation starts")
-            print("[HFCore.eval] metric computation starts")
             primary = float(m_stats.get("primary", np.nan))
             secondary = float(m_stats.get("secondary", np.nan))
             named_metrics = m_stats.get("named_metrics") if isinstance(m_stats, dict) else None
@@ -707,7 +706,6 @@ class HFCore:
             primary = np.nan
             secondary = np.nan
         else:
-            print("[HFCore.eval] metric computation starts")
             print("[HFCore.eval] metric computation starts")
             metrics_extra = dict(last_extra or {})
             metrics_extra["task_tag"] = self.task_tag


### PR DESCRIPTION
### Motivation
- Small capped Hugging Face runs using `max_samples` could pick the first N rows deterministically which often collapse label variety and produce degenerate accuracy (e.g., `{0: 100}`).
- Image `num_classes` inference from only sampled labels can be incorrect for small or biased samples, causing downstream logic to think there is a single class.
- The federated secondary metric naming for image classification was semantically misleading (`f1`) and duplicate eval log lines cluttered output.

### Description
- Shuffle HF splits before truncation when `max_samples` is set to avoid deterministic selection bias by adding a `shuffle(seed=...)` step in `mlaas_data_generator/data/sources/huggingface.py`.
- Improve image `num_classes` resolution in `mlaas_data_generator/data/preprocessors/hf_image.py` by reading `ClassLabel.names` / `num_classes` from the dataset `features` and combining that with sampled-label inference when available.
- Canonicalize image-classification auxiliary metric naming to return `("accuracy", "top5_accuracy")` for image tasks in `mlaas_data_generator/federated/strategies/base.py`.
- Remove duplicate `[HFCore.eval] metric computation starts` print lines in `mlaas_data_generator/models/adapters/hf_core.py` to reduce noisy logs.

### Testing
- Compiled the modified modules with `python -m compileall mlaas_data_generator/data/sources/huggingface.py mlaas_data_generator/data/preprocessors/hf_image.py mlaas_data_generator/federated/strategies/base.py mlaas_data_generator/models/adapters/hf_core.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de445d02e483308377a167bd44d475)