### PR TITLE
Fix object-detection eval class-index alignment for sparse COCO labels

### DIFF
--- a/mlaas_data_generator/models/adapters/hf_task.py
+++ b/mlaas_data_generator/models/adapters/hf_task.py
@@ -493,6 +493,25 @@ class ObjectDetectionSpec(HFTaskSpec):
             return mapped
         return class_ids
 
+    def _remap_predicted_class_indices_if_needed(self, class_indices, num_pred_classes):
+        class_ids = np.asarray(class_indices, dtype=np.int64)
+        valid_ids = self._model_valid_class_ids
+        if class_ids.size == 0 or not valid_ids:
+            return class_ids
+
+        # Some checkpoints expose contiguous prediction logits over only the
+        # valid classes while still publishing sparse COCO ids in id2label
+        # (e.g. valid ids start at 1). Detect that layout from the logits
+        # dimensionality and remap only in that case.
+        if (
+            valid_ids[0] == 1
+            and int(num_pred_classes) == int(len(valid_ids))
+            and int(np.min(class_ids)) >= 0
+            and int(np.max(class_ids)) < int(len(valid_ids))
+        ):
+            return np.asarray([int(valid_ids[int(cid)]) for cid in class_ids], dtype=np.int64)
+        return class_ids
+
     @staticmethod
     def _normalise_pixel_array(sample):
         arr = np.asarray(sample, dtype=np.float32)
@@ -646,8 +665,11 @@ class ObjectDetectionSpec(HFTaskSpec):
 
             p_scores = probs[bidx, :, :-1].max(axis=-1)
             p_cls = probs[bidx, :, :-1].argmax(axis=-1)
-            p_cls = self._remap_contiguous_classes_if_needed(p_cls, force=True)
+            p_cls = self._remap_predicted_class_indices_if_needed(p_cls, num_pred_classes=probs.shape[-1] - 1)
             keep = p_scores >= float(extra.get("score_threshold", self.score_threshold))
+            if self._model_valid_class_ids:
+                valid_set = set(int(v) for v in self._model_valid_class_ids)
+                keep = keep & np.asarray([int(cid) in valid_set for cid in p_cls], dtype=bool)
             p_scores = p_scores[keep]
             p_cls = p_cls[keep]
             p_boxes = boxes[bidx][keep]

--- a/mlaas_data_generator/test/test_hf_image_task_specs.py
+++ b/mlaas_data_generator/test/test_hf_image_task_specs.py
@@ -127,6 +127,27 @@ def test_object_detection_batch_metric_statistics_remaps_predicted_contiguous_id
     assert np.isclose(stats["tp_0.5"], 1.0)
 
 
+def test_object_detection_batch_metric_statistics_does_not_remap_detr_sparse_label_indices():
+    spec = ObjectDetectionSpec(score_threshold=0.05)
+    # Mimic DETR-style sparse COCO ids where valid class ids are non-contiguous
+    # and logits still include the sparse index space (plus no-object).
+    spec._model_valid_class_ids = [1, 2, 3, 5]
+    labels_t = [
+        {
+            "class_labels": torch.tensor([1], dtype=torch.long),
+            "boxes": torch.tensor([[0.5, 0.5, 0.4, 0.4]], dtype=torch.float32),
+        }
+    ]
+
+    class _Outputs:
+        # Argmax class index is 1 and should stay 1 (not remapped to 2).
+        logits = torch.tensor([[[0.1, 5.0, 0.2, 0.1, 0.0, -4.0]]], dtype=torch.float32)
+        pred_boxes = torch.tensor([[[0.5, 0.5, 0.4, 0.4]]], dtype=torch.float32)
+
+    stats = spec.batch_metric_statistics_from_outputs(torch, _Outputs(), labels_t, {"score_threshold": 0.05})
+    assert np.isclose(stats["tp_0.5"], 1.0)
+
+
 def test_object_detection_encode_batch_remaps_contiguous_coco_ids_when_model_uses_na_zero_slot():
     spec = ObjectDetectionSpec()
     # Mimic COCO-style id2label where index 0 is "N/A" and real classes start at 1.


### PR DESCRIPTION
### Motivation
- Evaluation produced implausibly low mAP for pretrained COCO DETR models because predicted class indices were being remapped unconditionally, causing predicted IDs to shift and inflate false positives when models use sparse/non-contiguous COCO ids.
- The intent is to align predicted and ground-truth IDs only when logits clearly represent a contiguous index space matching the model-declared valid ids, and to drop predictions that map to invalid/N/A ids.

### Description
- Added a new helper ` _remap_predicted_class_indices_if_needed` in `mlaas_data_generator/models/adapters/hf_task.py` that remaps predicted argmax indices only when `num_pred_classes` matches the number of `model_valid_class_ids` and the predicted indices are in the contiguous range.
- Replaced the previous forced prediction remapping in `batch_metric_statistics_from_outputs` with a call to ` _remap_predicted_class_indices_if_needed` and added post-filtering against `self._model_valid_class_ids` so predictions that map to invalid/N/A ids are ignored.
- Added a regression test `test_object_detection_batch_metric_statistics_does_not_remap_detr_sparse_label_indices` in `mlaas_data_generator/test/test_hf_image_task_specs.py` to cover DETR-style sparse COCO id behavior while keeping existing contiguous-remap tests intact.

### Testing
- Ran `python -m py_compile mlaas_data_generator/models/adapters/hf_task.py mlaas_data_generator/test/test_hf_image_task_specs.py` and it succeeded (syntax/compile check passed).
- Ran `pytest -q mlaas_data_generator/test/test_hf_image_task_specs.py`, which was attempted but failed in this environment due to a missing runtime dependency (`numpy`), so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de463c463483308f6d66f000e23566)