### PR TITLE
Fix HF image classification label-count inference when metadata is stale

### DIFF
--- a/mlaas_data_generator/data/preprocessors/hf_image.py
+++ b/mlaas_data_generator/data/preprocessors/hf_image.py
@@ -462,11 +462,18 @@ def preprocess_hf_image(
             feature_num_classes = None
 
     resolved_num_classes = meta.get("num_classes")
-    if resolved_num_classes is None:
-        if feature_num_classes is not None and inferred_num_classes is not None:
-            resolved_num_classes = int(max(feature_num_classes, inferred_num_classes))
-        else:
-            resolved_num_classes = feature_num_classes if feature_num_classes is not None else inferred_num_classes
+    if task_type == "classification":
+        candidates = []
+        for candidate in (resolved_num_classes, feature_num_classes, inferred_num_classes):
+            if candidate is None:
+                continue
+            try:
+                value = int(candidate)
+            except Exception:
+                continue
+            if value > 0:
+                candidates.append(value)
+        resolved_num_classes = int(max(candidates)) if candidates else None
     meta.update(
         {
             "input_shape": inferred_input_shape,

--- a/mlaas_data_generator/test/test_hf_image_preprocessor.py
+++ b/mlaas_data_generator/test/test_hf_image_preprocessor.py
@@ -7,9 +7,10 @@ from mlaas_data_generator.data.preprocessors.hf import preprocess_hf
 
 
 class DummySplit:
-    def __init__(self, rows):
+    def __init__(self, rows, *, features=None):
         self._rows = rows
         self.column_names = list(rows[0].keys()) if rows else []
+        self.features = features or {}
 
     def __len__(self):
         return len(self._rows)
@@ -60,6 +61,11 @@ class FakeImageProcessorCallKwargsButStrictPreprocess:
         if do_normalize and arr.max() > 1:
             arr = arr / 255.0
         return {"pixel_values": arr}
+
+
+class FakeClassLabel:
+    def __init__(self, names):
+        self.names = list(names)
 
 
 def _install_fake_transformers():
@@ -188,6 +194,23 @@ def test_image_classification_preserves_existing_num_classes_metadata():
         (DummySplit(test_rows), None),
         {"hf_task": "image_classification", "modality": "image", "task_type": "classification", "num_classes": 3, "hf_id": "dummy"},
         hf_model_id="dummy/vision",
+    )
+
+    assert meta["num_classes"] == 3
+
+
+def test_image_classification_uses_feature_classes_when_meta_is_too_small():
+    _install_fake_transformers()
+    label_feature = FakeClassLabel(["healthy", "angular_leaf_spot", "bean_rust"])
+    train_rows = [{"image": np.zeros((3, 3, 3), dtype=np.uint8), "label": 0}]
+    test_rows = [{"image": np.ones((3, 3, 3), dtype=np.uint8), "label": 1}]
+
+    _, _, meta = preprocess_hf(
+        (DummySplit(train_rows, features={"label": label_feature}), None),
+        (DummySplit(test_rows, features={"label": label_feature}), None),
+        {"hf_task": "image_classification", "modality": "image", "task_type": "classification", "num_classes": 1, "hf_id": "dummy"},
+        hf_model_id="dummy/vision",
+        label_column="label",
     )
 
     assert meta["num_classes"] == 3


### PR DESCRIPTION
### Motivation
- Runs with image datasets could end up with `num_classes: 1` from stale metadata, causing HF image classification models to be instantiated with a single-logit head and producing collapsed/incorrect predictions (e.g. 0.0 accuracy). 
- The intent is to robustly infer label-count for HF image tasks from the best available signals so model heads are sized correctly.

### Description
- Resolve `num_classes` in `preprocess_hf_image` by selecting the maximum valid positive candidate from `meta.get("num_classes")`, feature-schema values, and observed labels instead of trusting a possibly stale metadata value (file: `mlaas_data_generator/data/preprocessors/hf_image.py`).
- Add a regression test that covers the case where incoming metadata reports `num_classes=1` but the dataset feature schema contains 3 class names so the preprocessor updates `num_classes` to `3` (file: `mlaas_data_generator/test/test_hf_image_preprocessor.py`).
- Extend the test `DummySplit` fixture to optionally expose a `features` mapping so feature-level schema can be simulated in unit tests.

### Testing
- Compiled the updated modules with `python -m py_compile mlaas_data_generator/data/preprocessors/hf_image.py mlaas_data_generator/test/test_hf_image_preprocessor.py` which succeeded.
- Ran `pytest -q mlaas_data_generator/test/test_hf_image_preprocessor.py` but collection failed due to missing test environment dependency (`numpy` not installed); the new test is present and expected to pass when run in an environment with project test dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4683c7d483309dc3ed5ca3cb7b99)